### PR TITLE
chore: backport OWNERS_ALIASES to release-1.10

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -66,7 +66,9 @@ aliases:
   - spolti
   - vaibhavjainwiz
   eventing-natss-approvers:
-  - zhaojizhuang
+    - astelmashenko
+    - dan-j
+    - zhaojizhuang
   eventing-prometheus-approvers:
   - lberk
   - matzew


### PR DESCRIPTION
As per @pierDipi's comment on https://github.com/knative-extensions/eventing-natss/pull/426, backporting mine and @astelmashenko's approver status to the release-1.10 branch.