### PR TITLE
bump knative version to v1.12 in the kind tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,7 +18,7 @@ jobs:
         - v1.26.6
 
         eventing-version:
-        - knative-v1.11.4
+        - knative-v1.12.3
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.


### PR DESCRIPTION
We should increase the Knative version in the Kind tests to the most recent release (v1.12).

/cc @pierDipi @creydr 