### PR TITLE
fix: add .spec.subscribers[].name field in NATSS channel to align with eventing core

### DIFF
--- a/config/jetstream/302-jsm-channel.yaml
+++ b/config/jetstream/302-jsm-channel.yaml
@@ -306,6 +306,9 @@ spec:
                         description: Generation of the origin of the subscriber with uid:UID.
                         type: integer
                         format: int64
+                      name:
+                        description: The name of the subscription
+                        type: string
                       replyUri:
                         description: ReplyURI is the endpoint for the reply
                         type: string


### PR DESCRIPTION
Similar to https://github.com/knative-extensions/eventing-kafka-broker/pull/3845


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add .spec.subscribers[].name to the channel CRD