### PR TITLE
Remove deprecated yaml from release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,7 +24,6 @@ export GO111MODULE=on
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["eventing-natss.yaml"]="./config"
   ["eventing-jsm.yaml"]="./config/webhook,./config/jetstream"
 )
 readonly COMPONENTS


### PR DESCRIPTION
PTAL @astelmashenko 

If that makes sense now with removed natss bits. 