### PR TITLE
feat(tests): update kind workflow to newer k8s version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -15,18 +15,18 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.31.4
+        - v1.33.1
 
         eventing-version:
         - knative-v1.16.0
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
+        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.29.0
         include:
-        - k8s-version: v1.31.4
-          kind-version: v0.26.0
-          kind-image-sha: sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+        - k8s-version: 1.33.1
+          kind-version: v0.29.0
+          kind-image-sha: sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
     env:
       KO_DOCKER_REPO: kind.local
       SYSTEM_NAMESPACE: knative-eventing

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -24,7 +24,7 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.29.0
         include:
-        - k8s-version: 1.33.1
+        - k8s-version: v1.33.1
           kind-version: v0.29.0
           kind-image-sha: sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
     env:


### PR DESCRIPTION
Fixes #653 
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Switch to using the chainguard setup kind action
- Update kind workflow to newer k8s versions
- Update knative-eventing to newer version
