### PR TITLE
remove orphaned subscribers from nats jetstream channels

### DIFF
--- a/config/jetstream/200-jsm-dispatcher-clusterrole.yaml
+++ b/config/jetstream/200-jsm-dispatcher-clusterrole.yaml
@@ -24,12 +24,20 @@ rules:
     resources:
       - natsjetstreamchannels
       - natsjetstreamchannels/status
+      - natsjetstreamchannels/spec
     verbs:
       - get
       - list
       - watch
       - update
       - patch
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - list
   - apiGroups:
       - eventing.knative.dev
     resources:

--- a/pkg/channel/jetstream/dispatcher/controller.go
+++ b/pkg/channel/jetstream/dispatcher/controller.go
@@ -27,6 +27,7 @@ import (
 	jsminformer "knative.dev/eventing-natss/pkg/client/injection/informers/messaging/v1alpha1/natsjetstreamchannel"
 	"knative.dev/eventing-natss/pkg/common/configloader/fsloader"
 	"knative.dev/eventing/pkg/apis/eventing"
+	messagingv1client "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/pkg/injection"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
@@ -95,6 +96,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 
 	r := &Reconciler{
+		msgingClient:     messagingv1client.Get(ctx),
 		clientSet:        clientinject.Get(ctx),
 		js:               js,
 		dispatcher:       dispatcher,

--- a/pkg/channel/jetstream/dispatcher/dispatcher.go
+++ b/pkg/channel/jetstream/dispatcher/dispatcher.go
@@ -145,6 +145,8 @@ func (d *Dispatcher) ReconcileConsumers(ctx context.Context, config ChannelConfi
 		currentSubs = sets.New[string]()
 	}
 	expectedSubs := sets.New[string](config.SubscriptionsUIDs()...)
+	logger.Infow("expected", zap.Any("expected_subs", expectedSubs))
+	logger.Infow("current", zap.Any("current_subs", currentSubs))
 
 	toAddSubs := expectedSubs.Difference(currentSubs)
 	toRemoveSubs := currentSubs.Difference(expectedSubs)


### PR DESCRIPTION
There was an issues that sometime we observeved incosistency in actual subscribers CRDs and channels' list of subs. There were non-existent subs in channel. 

## Proposed Changes

This PR fixes that by checking list of subscription CRD against NastJetStreamChannel list of subscriptions.

**Release Note**

```release-note
Reconclier now can remove non-existing subscriptions.
```
