### PR TITLE
Make the NATS Broker control plane scalable

### DIFF
--- a/config/broker/500-broker-controller.yaml
+++ b/config/broker/500-broker-controller.yaml
@@ -21,7 +21,6 @@ metadata:
     nats.eventing.knative.dev/release: devel
     eventing.knative.dev/brokerRole: controller
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: natsjetstream-broker-controller
@@ -31,6 +30,16 @@ spec:
         app: natsjetstream-broker-controller
         eventing.knative.dev/brokerRole: controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: natsjetstream-broker-controller
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+
       serviceAccountName: natsjetstream-broker-controller
       containers:
         - name: controller

--- a/config/broker/500-shared-ingress.yaml
+++ b/config/broker/500-shared-ingress.yaml
@@ -20,7 +20,6 @@ metadata:
   labels:
     nats.eventing.knative.dev/release: devel
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: nats-broker-ingress

--- a/config/broker/501-shared-ingress-hpa.yaml
+++ b/config/broker/501-shared-ingress-hpa.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nats-broker-ingress-hpa
+  namespace: knative-eventing
+  labels:
+    nats.eventing.knative.dev/release: devel
+    eventing.knative.dev/brokerRole: ingress
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nats-broker-ingress
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/docs/broker.md
+++ b/docs/broker.md
@@ -32,6 +32,7 @@ Handles event delivery to trigger subscribers:
 ### Ingress (`natsjs-broker-ingress`)
 
 Receives events via HTTP and publishes them to JetStream streams.
+The shared ingress uses a HorizontalPodAutoscaler and requires the Kubernetes resource metrics API.
 
 ## Installation
 


### PR DESCRIPTION
## Why

The shared Broker ingress handles traffic for every NATS JetStream Broker in the cluster, but its Deployment was fixed at one replica. The Broker controller already supports leader election, but the manifest also fixed its replica count and did not express a scheduling preference for additional replicas.

The manifests should keep the one-replica Kubernetes default while allowing the ingress and controller to scale independently.

## Proposed Changes

- Add CPU-based autoscaling for the shared Broker ingress.
- Allow the Broker controller to scale independently, with replicas preferably scheduled across nodes.

**Release Note**

```release-note
The NATS Broker shared ingress now autoscales based on CPU utilization, with support for operator-managed scaling and replica spreading across nodes.
```
