### PR TITLE
Improve KinD E2E failure diagnostics

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -141,40 +141,32 @@ jobs:
 
     - name: Run e2e Tests
       run: |
+        set -o pipefail
         set -x
 
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -v -race -count=1 -timeout=15m -tags=e2e ./test/e2e/...
+        diagnostics_dir="${RUNNER_TEMP}/kind-e2e-diagnostics"
+        mkdir -p "${diagnostics_dir}"
+        go test -v -race -count=1 -timeout=15m -tags=e2e ./test/e2e/... 2>&1 | tee "${diagnostics_dir}/e2e-test.log"
 
     - name: Gather Failure Data
       if: ${{ failure() }}
+      continue-on-error: true
+      timeout-minutes: 5
+      env:
+        OUT_DIR: ${{ runner.temp }}/kind-e2e-diagnostics
       run: |
         set -x
+        bash ./hack/gather-e2e-failure-data.sh
 
-        echo "===================== Brokers =============================="
-        kubectl get broker --all-namespaces=true -oyaml
-
-        echo "===================== Channels ============================="
-        kubectl get channel --all-namespaces=true -oyaml
-
-        echo "===================== Triggers ============================="
-        kubectl get trigger --all-namespaces=true -oyaml
-
-        echo "===================== K8s Events ==========================="
-        kubectl get events --all-namespaces=true -oyaml
-
-        echo "===================== Pod Logs ============================="
-        namespace=knative-eventing
-        for pod in $(kubectl get pod -n $namespace | awk '{print $1}'); do
-          for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
-            echo "Namespace, Pod, Container: ${namespace}, ${pod}, ${container}"
-            kubectl logs -n $namespace "${pod}" -c "${container}" || true
-            echo "----------------------------------------------------------"
-            echo "Namespace, Pod, Container (Previous instance): ${namespace}, ${pod}, ${container}"
-            kubectl logs -p -n $namespace "${pod}" -c "${container}" || true
-            echo "============================================================"
-          done
-        done
+    - name: Upload Failure Data
+      if: ${{ always() && failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: kind-e2e-${{ matrix.k8s-version }}-${{ matrix.eventing-version }}
+        path: ${{ runner.temp }}/kind-e2e-diagnostics
+        if-no-files-found: warn
+        retention-days: 7
 
     - name: Post failure notice to Slack
       # Note: using env.SLACK_WEBHOOK here because secrets are not allowed in the if block.
@@ -189,4 +181,3 @@ jobs:
         SLACK_TITLE: Periodic e2e for Nats on kind on (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }}) failed.
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-

--- a/hack/gather-e2e-failure-data.sh
+++ b/hack/gather-e2e-failure-data.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Diagnostics must never hide the original test failure because one resource,
+# CRD, pod, or previous container instance is already gone.
+set +e
+
+OUT_DIR="${OUT_DIR:-diagnostics}"
+LOG_TAIL_LINES="${LOG_TAIL_LINES:-500}"
+LOG_LIMIT_BYTES="${LOG_LIMIT_BYTES:-1048576}"
+KUBECTL_COMMAND_TIMEOUT="${KUBECTL_COMMAND_TIMEOUT:-30s}"
+KUBECTL_KILL_AFTER="${KUBECTL_KILL_AFTER:-5s}"
+KUBECTL_REQUEST_TIMEOUT="${KUBECTL_REQUEST_TIMEOUT:-20s}"
+mkdir -p "${OUT_DIR}"
+
+# Bound both the client request and the process itself. The process timeout is
+# still needed when kubectl hangs before it can enforce its request deadline.
+kubectl_bounded() {
+  timeout --kill-after="${KUBECTL_KILL_AFTER}" "${KUBECTL_COMMAND_TIMEOUT}" \
+    kubectl --request-timeout="${KUBECTL_REQUEST_TIMEOUT}" "$@"
+}
+
+capture() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "${file}")"
+  {
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n'
+    "$@"
+  } >"${file}" 2>&1 || true
+}
+
+capture "${OUT_DIR}/brokers.yaml" kubectl_bounded get brokers --all-namespaces=true -o yaml
+capture "${OUT_DIR}/channels.yaml" kubectl_bounded get channels --all-namespaces=true -o yaml
+capture "${OUT_DIR}/natsjetstreamchannels.yaml" kubectl_bounded get natsjetstreamchannels.messaging.knative.dev --all-namespaces=true -o yaml
+capture "${OUT_DIR}/triggers.yaml" kubectl_bounded get triggers --all-namespaces=true -o yaml
+capture "${OUT_DIR}/scaledobjects.yaml" kubectl_bounded get scaledobjects.keda.sh --all-namespaces=true -o yaml
+capture "${OUT_DIR}/hpas.yaml" kubectl_bounded get horizontalpodautoscalers.autoscaling --all-namespaces=true -o yaml
+capture "${OUT_DIR}/events.yaml" kubectl_bounded get events --all-namespaces=true -o yaml
+
+# The NATS namespace is included with the two requested control-plane
+# namespaces because broker symptoms are otherwise disconnected from the
+# backing JetStream server logs.
+namespaces=(knative-eventing keda nats-io)
+while IFS= read -r namespace; do
+  if [[ -n "${namespace}" ]]; then
+    namespaces+=("${namespace}")
+  fi
+done < <(kubectl_bounded get namespaces \
+  -l app.kubernetes.io/component=reconciler-test \
+  -o 'jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+declare -A seen_namespaces=()
+for namespace in "${namespaces[@]}"; do
+  if [[ -n "${seen_namespaces[${namespace}]:-}" ]]; then
+    continue
+  fi
+  seen_namespaces["${namespace}"]=1
+
+  namespace_dir="${OUT_DIR}/namespaces/${namespace}"
+  mkdir -p "${namespace_dir}/logs"
+
+  # `describe` is intentionally forbidden: it prints literal environment
+  # values from Pod templates. Wide tables contain workload identity, image,
+  # placement, and status without dumping env or Secret values.
+  capture "${namespace_dir}/pods-wide.txt" kubectl_bounded get pods -n "${namespace}" -o wide
+  capture "${namespace_dir}/deployments-wide.txt" kubectl_bounded get deployments -n "${namespace}" -o wide
+  capture "${namespace_dir}/jobs-wide.txt" kubectl_bounded get jobs -n "${namespace}" -o wide
+
+  while IFS= read -r pod_ref; do
+    if [[ -z "${pod_ref}" ]]; then
+      continue
+    fi
+    pod="${pod_ref#pod/}"
+    containers="$(kubectl_bounded get pod "${pod}" -n "${namespace}" \
+      -o 'jsonpath={range .spec.initContainers[*]}{.name}{" "}{end}{range .spec.containers[*]}{.name}{" "}{end}{range .spec.ephemeralContainers[*]}{.name}{" "}{end}' 2>/dev/null || true)"
+    for container in ${containers}; do
+      capture "${namespace_dir}/logs/${pod}-${container}-current.log" \
+        kubectl_bounded logs -n "${namespace}" "${pod}" -c "${container}" \
+        --timestamps=true --tail="${LOG_TAIL_LINES}" --limit-bytes="${LOG_LIMIT_BYTES}"
+      capture "${namespace_dir}/logs/${pod}-${container}-previous.log" \
+        kubectl_bounded logs -n "${namespace}" "${pod}" -c "${container}" \
+        --timestamps=true --tail="${LOG_TAIL_LINES}" --limit-bytes="${LOG_LIMIT_BYTES}" --previous
+    done
+  done < <(kubectl_bounded get pods -n "${namespace}" -o name 2>/dev/null || true)
+done
+
+# Do not add `kubectl get/describe secrets` or any `kubectl describe` here.
+# Secret and literal Pod environment values are deliberately excluded.
+exit 0

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -43,16 +44,24 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// TestBrokerDirect makes sure a Broker can delivery events to a consumer.
-func TestBrokerDirect(t *testing.T) {
-	t.Parallel()
-	ctx, env := global.Environment(
+// testEnvironment keeps the environment lifecycle consistent across the E2E
+// suite. Managed environments clean up after successful tests and retain a
+// failed test's namespace for diagnostics.
+func testEnvironment(t *testing.T) (context.Context, environment.Environment) {
+	t.Helper()
+	return global.Environment(
+		environment.Managed(t),
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
 		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 	)
+}
+
+// TestBrokerDirect makes sure a Broker can delivery events to a consumer.
+func TestBrokerDirect(t *testing.T) {
+	t.Parallel()
+	ctx, env := testEnvironment(t)
 	env.Test(ctx, t, RecorderFeature())
 	env.Test(ctx, t, DirectTestBroker())
-	env.Finish()
 }

--- a/test/e2e/natsbroker_test.go
+++ b/test/e2e/natsbroker_test.go
@@ -30,12 +30,10 @@ import (
 	// logstream initialization.
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	_ "knative.dev/eventing-natss/test/defaultsystem"
-	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
-	"knative.dev/reconciler-test/pkg/knative"
 
 	"knative.dev/eventing-natss/test/e2e/config/deadletter"
 	"knative.dev/eventing-natss/test/e2e/config/filtering"
@@ -67,15 +65,9 @@ func namedRecorderFeature(name string) *feature.Feature {
 // TestNatsBrokerDirect tests that a NatsJetStream broker delivers events to a consumer.
 func TestNatsBrokerDirect(t *testing.T) {
 	t.Parallel()
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-	)
+	ctx, env := testEnvironment(t)
 	env.Test(ctx, t, RecorderFeature())
 	env.Test(ctx, t, NatsBrokerDirectFeature())
-	env.Finish()
 }
 
 // NatsBrokerDirectFeature tests direct event delivery through NatsJetStream broker.
@@ -104,15 +96,9 @@ func NatsBrokerDirectFeature() *feature.Feature {
 // TestNatsBrokerDeadLetter tests that a NatsJetStream broker sends failed events to a dead letter sink.
 func TestNatsBrokerDeadLetter(t *testing.T) {
 	t.Parallel()
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-	)
+	ctx, env := testEnvironment(t)
 	env.Test(ctx, t, namedRecorderFeature("dls-recorder"))
 	env.Test(ctx, t, NatsBrokerDeadLetterFeature())
-	env.Finish()
 }
 
 // NatsBrokerDeadLetterFeature tests that failed events reach the dead letter sink.
@@ -138,16 +124,10 @@ func NatsBrokerDeadLetterFeature() *feature.Feature {
 // TestNatsBrokerFiltering tests that a NatsJetStream broker routes events by type to the correct subscriber.
 func TestNatsBrokerFiltering(t *testing.T) {
 	t.Parallel()
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-	)
+	ctx, env := testEnvironment(t)
 	env.Test(ctx, t, namedRecorderFeature("recorder-type-a"))
 	env.Test(ctx, t, namedRecorderFeature("recorder-type-b"))
 	env.Test(ctx, t, NatsBrokerFilteringFeature())
-	env.Finish()
 }
 
 // NatsBrokerFilteringFeature tests type-based event routing through NatsJetStream broker.


### PR DESCRIPTION
## Why

KinD E2E failures were difficult to diagnose because test namespaces could be deleted before postmortem collection, one failed `kubectl` command could stop collection, and logs were not uploaded as bounded artifacts.

## Proposed Changes

- keep failed test namespaces available for postmortem collection
- save bounded cluster state and current/previous container logs without dumping Secrets or Pod environment values
- retain failure diagnostics as artifacts for seven days

**Release Note**

```release-note
NONE
```
