### PR TITLE
feat(delivery): support maximum backoff duration

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -3,34 +3,60 @@ name: KinD e2e tests
 on:
   push:
     branches: [ 'main', 'release-*' ]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'config/**'
+      - 'test/**'
+      - 'hack/**'
+      - 'third_party/**'
+      - '.github/workflows/kind-e2e.yaml'
   pull_request:
     branches: [ 'main', 'release-*' ]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'config/**'
+      - 'test/**'
+      - 'hack/**'
+      - 'third_party/**'
+      - '.github/workflows/kind-e2e.yaml'
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
 
-  ko-resolve:
-    name: e2e tests
+  e2e-tests:
+    name: e2e tests (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.34.3
+        - v1.34.x
+        - v1.35.x
 
         eventing-version:
-        - knative-v1.21.0
+        # Exercise compatibility with a supported Eventing installation.
+        - knative-v1.23.0
+        # Build the Eventing revision selected by go.mod.
+        - go.mod
 
-        # Map between K8s and KinD versions.
-        # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.29.0
-        include:
-        - k8s-version: v1.34.3
-          kind-version: v0.31.0
-          kind-image-sha: sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
     env:
       KO_DOCKER_REPO: kind.local
       SYSTEM_NAMESPACE: knative-eventing
-      KIND_CLUSTER_NAME: kind
 
     steps:
     - name: Defaults
@@ -43,75 +69,61 @@ jobs:
       uses: knative/actions/setup-go@main
 
     - name: Install ko
-      uses: ko-build/setup-ko@v0.7
+      uses: ko-build/setup-ko@v0.10
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
+
+    - name: Resolve Knative Eventing dependency
+      if: matrix.eventing-version == 'go.mod'
+      id: eventing-dependency
+      run: |
+        set -euo pipefail
+
+        eventing_version="$(go list -m -f '{{.Version}}' knative.dev/eventing)"
+        eventing_ref="$(
+          GOPROXY=direct go mod download -json "knative.dev/eventing@${eventing_version}" |
+            jq -er '.Origin.Hash'
+        )"
+        echo "ref=${eventing_ref}" >> "$GITHUB_OUTPUT"
+
+    - name: Check out Knative Eventing source
+      if: matrix.eventing-version == 'go.mod'
+      uses: actions/checkout@v7
+      with:
+        repository: knative/eventing
+        ref: ${{ steps.eventing-dependency.outputs.ref }}
+        path: .eventing-source
 
     - name: Install KinD
-      env:
-        KIND_VERSION: ${{ matrix.kind-version }}
+      uses: chainguard-dev/actions/setup-kind@c69a264ec2a5934c3186c618f368fc1c86f16cff # main
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+        kind-worker-count: 1
+        cluster-suffix: cluster.local
+
+    - name: Install NATS
       run: |
         set -x
 
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
-
-    - name: Create KinD Cluster
-      run: |
-        set -x
-
-        # KinD configuration.
-        cat > kind.yaml <<EOF
-        apiVersion: kind.x-k8s.io/v1alpha4
-        kind: Cluster
-
-        # This is needed in order to support projected volumes with service account tokens.
-        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
-        kubeadmConfigPatches:
-          - |
-            apiVersion: kubeadm.k8s.io/v1beta2
-            kind: ClusterConfiguration
-            metadata:
-              name: config
-            apiServer:
-              extraArgs:
-                "service-account-issuer": "kubernetes.default.svc"
-                "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
-        nodes:
-        - role: control-plane
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-        - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-
-        EOF
-
-        # Create a cluster!
-        kind create cluster --config kind.yaml
-
-    - name: Install nats
-      run: |
-        set -x
-
-        kubectl create namespace nats
-        kubectl apply -n nats-io -f ./config/mtbroker/natsjsm.yaml
+        kubectl apply -f ./config/mtbroker/natsjsm.yaml
         # Create a ConfigMap that we use to instruct Broker to create nats channels.
-        kubectl create namespace knative-eventing
-        kubectl apply -n knative-eventing -f ./config/mtbroker/config-br-default-channel-jsm.yaml
-        kubectl apply -n knative-eventing -f ./config/mtbroker/config-nats.yaml
-        
+        kubectl create namespace ${SYSTEM_NAMESPACE}
+        kubectl apply -n ${SYSTEM_NAMESPACE} -f ./config/mtbroker/config-br-default-channel-jsm.yaml
+        kubectl apply -n ${SYSTEM_NAMESPACE} -f ./config/mtbroker/config-nats.yaml
+
         set +x
         source ./vendor/knative.dev/hack/infra-library.sh
         wait_until_pods_running nats-io
-        
+
         set -x
         kubectl get pods -n nats-io
         kubectl get svc nats -n nats-io
         kubectl get pods -n kube-system -l k8s-app=kube-dns
         kubectl logs -n kube-system -l k8s-app=kube-dns
 
-    - name: Install Knative Eventing
+    - name: Install released Knative Eventing
+      if: matrix.eventing-version != 'go.mod'
       run: |
         set -x
 
@@ -120,73 +132,88 @@ jobs:
         kubectl apply --filename https://github.com/knative/eventing/releases/download/${{ matrix.eventing-version }}/eventing-core.yaml
         kubectl apply --filename https://github.com/knative/eventing/releases/download/${{ matrix.eventing-version }}/mt-channel-broker.yaml
 
-    - name: Install
+    - name: Build and install Knative Eventing source
+      if: matrix.eventing-version == 'go.mod'
+      working-directory: .eventing-source
+      run: |
+        set -x
+
+        ko apply --platform=linux/amd64 -R -f ./config/core/
+        ko apply --platform=linux/amd64 -f ./config/brokers/mt-channel-broker/
+
+    - name: Install NATS Eventing components
       run: |
         set -x
         # TODO: this should use the release script and then apply the newly created release yaml in the future.
 
-        # Install the nats channel
-        ko apply -f ./config/webhook
-        ko apply -f ./config/jetstream
-        ko apply -f ./config/broker
+        ko apply --platform=linux/amd64 -f ./config/webhook
+        ko apply --platform=linux/amd64 -f ./config/jetstream
+        ko apply --platform=linux/amd64 -f ./config/broker
 
-    - name: Wait for Ready
+    - name: Wait for things to be up
       run: |
         set -e
         source ./vendor/knative.dev/hack/infra-library.sh
         wait_until_pods_running ${SYSTEM_NAMESPACE}
-        
+
         # For debugging.
         kubectl get pods --all-namespaces
 
     - name: Run e2e Tests
       run: |
-        set -x
-
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -v -race -count=1 -timeout=15m -tags=e2e ./test/e2e/...
+        go test -race -count=1 -parallel=12 -timeout=90m -tags=e2e \
+          ./test/e2e
 
-    - name: Gather Failure Data
+    - name: Collect system diagnostics
       if: ${{ failure() }}
       run: |
-        set -x
-
-        echo "===================== Brokers =============================="
+        echo '::group:: brokers'
         kubectl get broker --all-namespaces=true -oyaml
+        echo '::endgroup::'
 
-        echo "===================== Channels ============================="
+        echo '::group:: channels'
         kubectl get channel --all-namespaces=true -oyaml
+        echo '::endgroup::'
 
-        echo "===================== Triggers ============================="
+        echo '::group:: triggers'
         kubectl get trigger --all-namespaces=true -oyaml
+        echo '::endgroup::'
 
-        echo "===================== K8s Events ==========================="
-        kubectl get events --all-namespaces=true -oyaml
+        echo '::group:: all pods'
+        kubectl get pods --all-namespaces=true
+        echo '::endgroup::'
 
-        echo "===================== Pod Logs ============================="
-        namespace=knative-eventing
-        for pod in $(kubectl get pod -n $namespace | awk '{print $1}'); do
-          for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
-            echo "Namespace, Pod, Container: ${namespace}, ${pod}, ${container}"
-            kubectl logs -n $namespace "${pod}" -c "${container}" || true
-            echo "----------------------------------------------------------"
-            echo "Namespace, Pod, Container (Previous instance): ${namespace}, ${pod}, ${container}"
-            kubectl logs -p -n $namespace "${pod}" -c "${container}" || true
-            echo "============================================================"
+        for namespace in ${SYSTEM_NAMESPACE} nats-io; do
+          echo "::group:: describe ${namespace} pods"
+          kubectl -n "${namespace}" describe pods || true
+          echo '::endgroup::'
+
+          for pod in $(kubectl -n "${namespace}" get pods -oname); do
+            echo "::group:: ${namespace} ${pod} logs"
+            kubectl -n "${namespace}" logs "${pod}" --all-containers || true
+            echo '::endgroup::'
+
+            echo "::group:: ${namespace} ${pod} previous logs"
+            kubectl -n "${namespace}" logs "${pod}" --all-containers --previous || true
+            echo '::endgroup::'
           done
         done
+
+        echo '::group:: all events'
+        kubectl get events --all-namespaces=true -oyaml
+        echo '::endgroup::'
 
     - name: Post failure notice to Slack
       # Note: using env.SLACK_WEBHOOK here because secrets are not allowed in the if block.
       if: ${{ env.SLACK_WEBHOOK != '' && failure() && github.event_name != 'pull_request' }}
-      uses: rtCamp/action-slack-notify@v2.1.0
+      uses: rtCamp/action-slack-notify@v2.4.0
       env:
-        SLACK_ICON: http://github.com/knative.png?size=48
+        SLACK_ICON: https://github.com/knative.png?size=48
         SLACK_USERNAME: github-actions
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_CHANNEL: 'eventing-delivery'
         MSG_MINIMAL: 'true'
-        SLACK_TITLE: Periodic e2e for Nats on kind on (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }}) failed.
+        SLACK_TITLE: Periodic e2e for NATS on KinD on (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }}) failed.
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -38,7 +38,7 @@ permissions:
 jobs:
 
   e2e-tests:
-    name: e2e tests (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }})
+    name: e2e tests (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }}, ${{ matrix.test-suite }})
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -53,6 +53,15 @@ jobs:
         - knative-v1.23.0
         # Build the Eventing revision selected by go.mod.
         - go.mod
+
+        test-suite:
+        - ./test/e2e
+        - ./test/experimental
+
+        exclude:
+        # Experimental tests exercise the API selected by go.mod.
+        - eventing-version: knative-v1.23.0
+          test-suite: ./test/experimental
 
     env:
       KO_DOCKER_REPO: kind.local
@@ -141,6 +150,11 @@ jobs:
         ko apply --platform=linux/amd64 -R -f ./config/core/
         ko apply --platform=linux/amd64 -f ./config/brokers/mt-channel-broker/
 
+    - name: Apply experimental features config
+      if: matrix.test-suite == './test/experimental'
+      run: |
+        kubectl apply -f ./test/experimental/config
+
     - name: Install NATS Eventing components
       run: |
         set -x
@@ -163,7 +177,7 @@ jobs:
       run: |
         # Run the tests tagged as e2e on the KinD cluster.
         go test -race -count=1 -parallel=12 -timeout=90m -tags=e2e \
-          ./test/e2e
+          ${{ matrix.test-suite }}
 
     - name: Collect system diagnostics
       if: ${{ failure() }}
@@ -214,6 +228,6 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_CHANNEL: 'eventing-delivery'
         MSG_MINIMAL: 'true'
-        SLACK_TITLE: Periodic e2e for NATS on KinD on (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }}) failed.
+        SLACK_TITLE: Periodic e2e for NATS on KinD on (${{ matrix.k8s-version }}, ${{ matrix.eventing-version }}, ${{ matrix.test-suite }}) failed.
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/config/jetstream/302-jsm-channel.yaml
+++ b/config/jetstream/302-jsm-channel.yaml
@@ -106,6 +106,9 @@ spec:
                     backoffDelay:
                       description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                       type: string
+                    backoffMax:
+                      description: 'BackoffMax is the maximum delay between normal delivery attempts. It caps the delay calculated from BackoffDelay and BackoffPolicy, but does not cap delays requested by a Retry-After response header. The value must be greater than zero. Cluster operators must enable the delivery-backoff-max feature before users can set this experimental field. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601'
+                      type: string
                     backoffPolicy:
                       description: BackoffPolicy is the retry backoff policy (linear, exponential).
                       type: string
@@ -739,6 +742,9 @@ spec:
                         properties:
                           backoffDelay:
                             description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
+                            type: string
+                          backoffMax:
+                            description: 'BackoffMax is the maximum delay between normal delivery attempts. It caps the delay calculated from BackoffDelay and BackoffPolicy, but does not cap delays requested by a Retry-After response header. The value must be greater than zero. Cluster operators must enable the delivery-backoff-max feature before users can set this experimental field. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601'
                             type: string
                           backoffPolicy:
                             description: BackoffPolicy is the retry backoff policy (linear, exponential).

--- a/docs/broker.md
+++ b/docs/broker.md
@@ -158,21 +158,28 @@ spec:
     backoffPolicy: exponential
     backoffDelay: PT1S
     backoffMax: PT4S
+    retryAfterMax: PT6S
 ```
 
 ### Delivery retry limits
 
-The Trigger owner uses `backoffMax` to keep normal retry delays bounded when
-`my-service` is unavailable. With the example above, the Broker filter requests
-delays of `1s`, `2s`, `4s`, `4s`, `4s`, and `4s`. Scheduling and processing
-load can cause the next delivery to occur later.
+The Trigger owner uses these fields to keep retry delays bounded when
+`my-service` is unavailable. With the example above, the normal exponential
+delays calculated by the Broker filter are `1s`, `2s`, `4s`, `4s`, `4s`, and
+`4s`.
 
-`backoffMax` limits only the delay calculated from `backoffDelay` and
-`backoffPolicy`; it does not alter a delay requested through a `Retry-After`
-response header.
+| Field | Delay it limits | When it applies | Example result |
+|-------|-----------------|-----------------|----------------|
+| `backoffMax` | The delay calculated from `backoffDelay` and `backoffPolicy` | Every normal retry | `PT4S` stops the exponential sequence at 4 seconds |
+| `retryAfterMax` | A delay requested by a subscriber's `Retry-After` response header | HTTP 429 and 503 responses | `PT6S` reduces `Retry-After: 10` to 6 seconds |
 
-Cluster operators must enable the experimental field in the Knative Eventing
-`config-features` ConfigMap before Trigger or Broker owners use it:
+For a 429 or 503 response, the Broker uses the larger of the normal backoff and
+the capped `Retry-After` value. These fields limit the delay requested from
+JetStream; scheduling and processing load can cause the next delivery to occur
+later.
+
+Cluster operators must enable both experimental fields in the Knative Eventing
+`config-features` ConfigMap before Trigger or Broker owners use this example:
 
 ```yaml
 apiVersion: v1
@@ -182,6 +189,7 @@ metadata:
   namespace: knative-eventing
 data:
   delivery-backoff-max: enabled
+  delivery-retryafter: enabled
 ```
 
 ## Configuration

--- a/docs/broker.md
+++ b/docs/broker.md
@@ -154,9 +154,34 @@ spec:
         apiVersion: v1
         kind: Service
         name: dead-letter-service
-    retry: 3
+    retry: 6
     backoffPolicy: exponential
     backoffDelay: PT1S
+    backoffMax: PT4S
+```
+
+### Delivery retry limits
+
+The Trigger owner uses `backoffMax` to keep normal retry delays bounded when
+`my-service` is unavailable. With the example above, the Broker filter requests
+delays of `1s`, `2s`, `4s`, `4s`, `4s`, and `4s`. Scheduling and processing
+load can cause the next delivery to occur later.
+
+`backoffMax` limits only the delay calculated from `backoffDelay` and
+`backoffPolicy`; it does not alter a delay requested through a `Retry-After`
+response header.
+
+Cluster operators must enable the experimental field in the Knative Eventing
+`config-features` ConfigMap before Trigger or Broker owners use it:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-eventing
+data:
+  delivery-backoff-max: enabled
 ```
 
 ## Configuration

--- a/docs/jetstream.md
+++ b/docs/jetstream.md
@@ -149,6 +149,48 @@ Consumers will be created with the default configuration:
 
 Other configuration elements use the JetStream defaults, and can be overridden in the CRD.
 
+## Configuring delivery retries
+
+A channel operator can set default retry behavior on a
+`NatsJetStreamChannel`. Every `Subscription` without its own delivery settings
+then uses that default. In this example, events for `orders` are retried four
+times and the normal exponential delay stops growing at two seconds:
+
+```yaml
+apiVersion: messaging.knative.dev/v1alpha1
+kind: NatsJetStreamChannel
+metadata:
+  name: orders
+  namespace: default
+spec:
+  delivery:
+    retry: 4
+    backoffPolicy: exponential
+    backoffDelay: PT1S
+    backoffMax: PT2S
+---
+apiVersion: messaging.knative.dev/v1
+kind: Subscription
+metadata:
+  name: orders-to-processor
+  namespace: default
+spec:
+  channel:
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: NatsJetStreamChannel
+    name: orders
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: order-processor
+```
+
+Cluster operators must enable `delivery-backoff-max` in the Knative Eventing
+`config-features` ConfigMap before applying this channel. See
+[Delivery retry limits](./broker.md#delivery-retry-limits) for the difference
+between `backoffMax` and `retryAfterMax` and for the required feature flags.
+
 ## `NatsJetStreamChannel` CRD
 
 ```yaml

--- a/pkg/apis/messaging/v1alpha1/nats_jetstream_channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/nats_jetstream_channel_validation.go
@@ -43,11 +43,21 @@ func (c *NatsJetStreamChannel) Validate(ctx context.Context) *apis.FieldError {
 
 func (cs *NatsJetStreamChannelSpec) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
+	if cs.Delivery != nil {
+		if fe := cs.Delivery.Validate(ctx); fe != nil {
+			errs = errs.Also(fe.ViaField("delivery"))
+		}
+	}
 	for i, subscriber := range cs.Subscribers {
 		if subscriber.ReplyURI == nil && subscriber.SubscriberURI == nil {
 			fe := apis.ErrMissingField("replyURI", "subscriberURI")
 			fe.Details = "expected at least one of, got none"
 			errs = errs.Also(fe.ViaField(fmt.Sprintf("subscriber[%d]", i)).ViaField("subscribable"))
+		}
+		if subscriber.Delivery != nil {
+			if fe := subscriber.Delivery.Validate(ctx); fe != nil {
+				errs = errs.Also(fe.ViaField("delivery").ViaIndex(i).ViaField("subscribers"))
+			}
 		}
 	}
 	return errs

--- a/pkg/apis/messaging/v1alpha1/nats_jetstream_channel_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/nats_jetstream_channel_validation_test.go
@@ -162,6 +162,60 @@ func TestNatssChannelValidation(t *testing.T) {
 			},
 			want: apis.ErrInvalidValue(int32(-1), "retry").ViaField("delivery").ViaIndex(0).ViaField("subscribers").ViaField("spec"),
 		},
+		"backoff max accepted when feature enabled": {
+			ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.DeliveryBackoffMax: feature.Enabled,
+			}),
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{BackoffMax: ptr.To("PT2S")},
+				}},
+			},
+		},
+		"backoff max rejected when feature disabled": {
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{BackoffMax: ptr.To("PT2S")},
+				}},
+			},
+			want: apis.ErrDisallowedFields("backoffMax").ViaField("delivery").ViaField("spec"),
+		},
+		"invalid default backoff max": {
+			ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.DeliveryBackoffMax: feature.Enabled,
+			}),
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{BackoffMax: ptr.To("PT0S")},
+				}},
+			},
+			want: apis.ErrInvalidValue("PT0S", "backoffMax").ViaField("delivery").ViaField("spec"),
+		},
+		"negative default backoff max": {
+			ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.DeliveryBackoffMax: feature.Enabled,
+			}),
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{BackoffMax: ptr.To("-PT1S")},
+				}},
+			},
+			want: apis.ErrInvalidValue("-PT1S", "backoffMax").ViaField("delivery").ViaField("spec"),
+		},
+		"invalid subscriber backoff max": {
+			ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.DeliveryBackoffMax: feature.Enabled,
+			}),
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					SubscribableSpec: eventingduckv1.SubscribableSpec{Subscribers: []eventingduckv1.SubscriberSpec{{
+						SubscriberURI: aURL,
+						Delivery:      &eventingduckv1.DeliverySpec{BackoffMax: ptr.To("not-a-duration")},
+					}}},
+				}},
+			},
+			want: apis.ErrInvalidValue("not-a-duration", "backoffMax").ViaField("delivery").ViaIndex(0).ViaField("subscribers").ViaField("spec"),
+		},
 	}
 
 	for n, test := range testCases {

--- a/pkg/apis/messaging/v1alpha1/nats_jetstream_channel_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/nats_jetstream_channel_validation_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/utils/ptr"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/webhook/resourcesemantics"
@@ -30,8 +32,11 @@ import (
 
 func TestNatssChannelValidation(t *testing.T) {
 	aURL, _ := apis.ParseURL("http://example.com")
+	invalidPolicy := eventingduckv1.BackoffPolicyType("invalid")
+	invalidFormat := eventingduckv1.FormatType("invalid")
 
 	testCases := map[string]struct {
+		ctx  context.Context
 		cr   resourcesemantics.GenericCRD
 		want *apis.FieldError
 	}{
@@ -96,11 +101,76 @@ func TestNatssChannelValidation(t *testing.T) {
 				return errs
 			}(),
 		},
+		"negative default retry": {
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{Retry: ptr.To(int32(-1))},
+				}},
+			},
+			want: apis.ErrInvalidValue(int32(-1), "retry").ViaField("delivery").ViaField("spec"),
+		},
+		"invalid default backoff policy": {
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{BackoffPolicy: &invalidPolicy},
+				}},
+			},
+			want: apis.ErrInvalidValue(invalidPolicy, "backoffPolicy").ViaField("delivery").ViaField("spec"),
+		},
+		"malformed default backoff delay": {
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{BackoffDelay: ptr.To("not-a-duration")},
+				}},
+			},
+			want: apis.ErrInvalidValue("not-a-duration", "backoffDelay").ViaField("delivery").ViaField("spec"),
+		},
+		"invalid default format": {
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{Format: &invalidFormat},
+				}},
+			},
+			want: apis.ErrInvalidValue(invalidFormat, "format").ViaField("delivery").ViaField("spec"),
+		},
+		"retry after max rejected when feature disabled": {
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{RetryAfterMax: ptr.To("PT2S")},
+				}},
+			},
+			want: apis.ErrDisallowedFields("retryAfterMax").ViaField("delivery").ViaField("spec"),
+		},
+		"retry after max accepted when feature enabled": {
+			ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.DeliveryRetryAfter: feature.Enabled,
+			}),
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{RetryAfterMax: ptr.To("PT2S")},
+				}},
+			},
+		},
+		"negative subscriber retry": {
+			cr: &NatsJetStreamChannel{
+				Spec: NatsJetStreamChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					SubscribableSpec: eventingduckv1.SubscribableSpec{Subscribers: []eventingduckv1.SubscriberSpec{{
+						SubscriberURI: aURL,
+						Delivery:      &eventingduckv1.DeliverySpec{Retry: ptr.To(int32(-1))},
+					}}},
+				}},
+			},
+			want: apis.ErrInvalidValue(int32(-1), "retry").ViaField("delivery").ViaIndex(0).ViaField("subscribers").ViaField("spec"),
+		},
 	}
 
 	for n, test := range testCases {
 		t.Run(n, func(t *testing.T) {
-			got := test.cr.Validate(context.Background())
+			ctx := test.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			got := test.cr.Validate(ctx)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("%s: validate (-want, +got) = %v", n, diff)
 			}

--- a/pkg/broker/filter/handler.go
+++ b/pkg/broker/filter/handler.go
@@ -394,7 +394,11 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 		} else {
 			span.SetAttributes(attribute.String("nats.result", "nak"))
 			// Nack for retry
-			nakDelay := jsutils.CalculateNakDelayForRetryNumber(retryNumber, h.retryConfig)
+			response := &http.Response{
+				StatusCode: dispatchInfo.ResponseCode,
+				Header:     dispatchInfo.ResponseHeader,
+			}
+			nakDelay := jsutils.CalculateNakDelayForRetryNumber(retryNumber, h.retryConfig, response)
 			if err := msg.NakWithDelay(nakDelay, nats.Context(ctx)); err != nil {
 				logger.Errorw("failed to nack message", zap.Error(err))
 			}

--- a/pkg/broker/utils/delivery.go
+++ b/pkg/broker/utils/delivery.go
@@ -29,6 +29,7 @@ func DeliveryIsSet(d *eventingduckv1.DeliverySpec) bool {
 		d.Timeout != nil ||
 		d.BackoffPolicy != nil ||
 		d.BackoffDelay != nil ||
+		d.BackoffMax != nil ||
 		d.RetryAfterMax != nil ||
 		d.Format != nil)
 }

--- a/pkg/broker/utils/delivery_test.go
+++ b/pkg/broker/utils/delivery_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestDeliveryIsSet(t *testing.T) {
 	r := int32(1)
+	backoffMax := "PT10M"
 	tests := []struct {
 		name string
 		spec *eventingduckv1.DeliverySpec
@@ -35,6 +36,7 @@ func TestDeliveryIsSet(t *testing.T) {
 		{name: "nil", spec: nil, want: false},
 		{name: "empty", spec: &eventingduckv1.DeliverySpec{}, want: false},
 		{name: "retry set", spec: &eventingduckv1.DeliverySpec{Retry: &r}, want: true},
+		{name: "backoff max set", spec: &eventingduckv1.DeliverySpec{BackoffMax: &backoffMax}, want: true},
 		{name: "dls set", spec: &eventingduckv1.DeliverySpec{DeadLetterSink: &duckv1.Destination{}}, want: true},
 	}
 	for _, tc := range tests {
@@ -59,6 +61,7 @@ func TestEffectiveDelivery(t *testing.T) {
 	tDLS := &duckv1.Destination{}
 	bDLS := &duckv1.Destination{}
 	r2, r5 := int32(2), int32(5)
+	backoffMax := "PT4S"
 
 	tests := []struct {
 		name      string
@@ -67,6 +70,7 @@ func TestEffectiveDelivery(t *testing.T) {
 		wantSpec  *eventingduckv1.DeliverySpec // expected identity of the returned spec
 		wantRetry *int32
 		wantDLS   *duckv1.Destination
+		wantMax   *string
 	}{
 		{name: "both nil"},
 		{
@@ -94,6 +98,14 @@ func TestEffectiveDelivery(t *testing.T) {
 			broker:    &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS},
 			wantRetry: &r5, wantDLS: bDLS,
 		},
+		{
+			name:      "trigger backoff max alone wins wholesale",
+			trigger:   &eventingduckv1.DeliverySpec{BackoffMax: &backoffMax},
+			broker:    &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS},
+			wantMax:   &backoffMax,
+			wantRetry: nil,
+			wantDLS:   nil,
+		},
 	}
 
 	for _, tc := range tests {
@@ -110,6 +122,9 @@ func TestEffectiveDelivery(t *testing.T) {
 			}
 			if got.DeadLetterSink != tc.wantDLS {
 				t.Errorf("DeadLetterSink = %v, want %v", got.DeadLetterSink, tc.wantDLS)
+			}
+			if got.BackoffMax != tc.wantMax {
+				t.Errorf("BackoffMax = %v, want %v", got.BackoffMax, tc.wantMax)
 			}
 		})
 	}

--- a/pkg/channel/jetstream/dispatcher/message_dispatcher.go
+++ b/pkg/channel/jetstream/dispatcher/message_dispatcher.go
@@ -33,7 +33,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/hashicorp/go-retryablehttp"
 	"k8s.io/apimachinery/pkg/types"
 	jsutils "knative.dev/eventing-natss/pkg/channel/jetstream/utils"
 
@@ -46,9 +45,6 @@ import (
 
 //go:linkname getClientForAddressable knative.dev/eventing/pkg/kncloudevents.getClientForAddressable
 func getClientForAddressable(addressable duckv1.Addressable) (*http.Client, error)
-
-//go:linkname generateBackoffFn knative.dev/eventing/pkg/kncloudevents.generateBackoffFn
-func generateBackoffFn(config *kncloudevents.RetryConfig) retryablehttp.Backoff
 
 //go:linkname sanitizeAddressable knative.dev/eventing/pkg/kncloudevents.sanitizeAddressable
 func sanitizeAddressable(addressable *duckv1.Addressable) *duckv1.Addressable
@@ -275,7 +271,11 @@ func processDispatchResult(ctx context.Context, msg *nats.Msg, retryConfig *kncl
 			logger.Error("failed to Ack message after successful delivery to subscriber", zap.Error(err))
 		}
 	case protocol.IsNACK(result):
-		if err := msg.NakWithDelay(jsutils.CalculateNakDelayForRetryNumber(retryNumber, retryConfig), nats.Context(ctx)); err != nil {
+		response := &http.Response{
+			StatusCode: dispatchExecutionInfo.ResponseCode,
+			Header:     dispatchExecutionInfo.ResponseHeader,
+		}
+		if err := msg.NakWithDelay(jsutils.CalculateNakDelayForRetryNumber(retryNumber, retryConfig, response), nats.Context(ctx)); err != nil {
 			logger.Error("failed to Nack message after failed delivery to subscriber", zap.Error(err))
 		}
 	default:

--- a/pkg/channel/jetstream/dispatcher/message_dispatcher_test.go
+++ b/pkg/channel/jetstream/dispatcher/message_dispatcher_test.go
@@ -560,15 +560,10 @@ func TestDispatchMessage(t *testing.T) {
 			var retryConfig kncloudevents.RetryConfig
 			if tc.delivery == nil {
 				retryConfig = kncloudevents.NoRetries()
-				backoffLinear := v1.BackoffPolicyLinear
-				retryConfig.BackoffPolicy = &backoffLinear
-				backoffDelay := "5s"
-				retryConfig.BackoffDelay = &backoffDelay
 			} else {
-				retryConfig = kncloudevents.RetryConfig{
-					RetryMax:      int(*tc.delivery.Retry),
-					BackoffPolicy: tc.delivery.BackoffPolicy,
-					BackoffDelay:  tc.delivery.BackoffDelay,
+				retryConfig, err = kncloudevents.RetryConfigFromDeliverySpec(*tc.delivery)
+				if err != nil {
+					t.Fatal(err)
 				}
 			}
 

--- a/pkg/channel/jetstream/utils/consumerconfig.go
+++ b/pkg/channel/jetstream/utils/consumerconfig.go
@@ -17,14 +17,21 @@ limitations under the License.
 package utils
 
 import (
+	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/nats-io/nats.go"
 	"knative.dev/eventing-natss/pkg/apis/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/kncloudevents"
+
+	_ "unsafe"
 )
+
+//go:linkname generateBackoffFn knative.dev/eventing/pkg/kncloudevents.generateBackoffFn
+func generateBackoffFn(config *kncloudevents.RetryConfig) retryablehttp.Backoff
 
 func ConvertJsDeliverPolicy(in v1alpha1.DeliverPolicy, def jetstream.DeliverPolicy) jetstream.DeliverPolicy {
 	switch in {
@@ -110,7 +117,7 @@ func CalcRequestTimeout(numDelivered int, ackWait time.Duration) time.Duration {
 // CalculateNakDelayForRetryNumber calculates the NAK delay for a JetStream
 // delivery. JetStream's NumDelivered is one-based, while Knative's retry
 // backoff callback receives a zero-based retry attempt.
-func CalculateNakDelayForRetryNumber(numDelivered int, config *kncloudevents.RetryConfig) time.Duration {
+func CalculateNakDelayForRetryNumber(numDelivered int, config *kncloudevents.RetryConfig, response *http.Response) time.Duration {
 	if config == nil || config.Backoff == nil {
 		return 0
 	}
@@ -118,5 +125,5 @@ func CalculateNakDelayForRetryNumber(numDelivered int, config *kncloudevents.Ret
 	if attemptNum < 0 {
 		attemptNum = 0
 	}
-	return config.Backoff(attemptNum, nil)
+	return generateBackoffFn(config)(0, 0, attemptNum, response)
 }

--- a/pkg/channel/jetstream/utils/consumerconfig.go
+++ b/pkg/channel/jetstream/utils/consumerconfig.go
@@ -110,7 +110,14 @@ func CalcRequestTimeout(numDelivered int, ackWait time.Duration) time.Duration {
 	return deadline
 }
 
-func CalculateNakDelayForRetryNumber(attemptNum int, config *kncloudevents.RetryConfig) time.Duration {
+// CalculateNakDelayForRetryNumber calculates the NAK delay for a JetStream
+// delivery. JetStream's NumDelivered is one-based, while Knative's retry
+// backoff callback receives a zero-based retry attempt.
+func CalculateNakDelayForRetryNumber(numDelivered int, config *kncloudevents.RetryConfig) time.Duration {
+	attemptNum := numDelivered - 1
+	if attemptNum < 0 {
+		attemptNum = 0
+	}
 	backoff, backoffDelay := parseBackoffFuncAndDelay(config)
 	return backoff(attemptNum, backoffDelay)
 }

--- a/pkg/channel/jetstream/utils/consumerconfig.go
+++ b/pkg/channel/jetstream/utils/consumerconfig.go
@@ -17,15 +17,12 @@ limitations under the License.
 package utils
 
 import (
-	"math"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/nats-io/nats.go"
-	"github.com/rickb777/date/period"
 	"knative.dev/eventing-natss/pkg/apis/messaging/v1alpha1"
-	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/kncloudevents"
 )
 
@@ -114,35 +111,12 @@ func CalcRequestTimeout(numDelivered int, ackWait time.Duration) time.Duration {
 // delivery. JetStream's NumDelivered is one-based, while Knative's retry
 // backoff callback receives a zero-based retry attempt.
 func CalculateNakDelayForRetryNumber(numDelivered int, config *kncloudevents.RetryConfig) time.Duration {
+	if config == nil || config.Backoff == nil {
+		return 0
+	}
 	attemptNum := numDelivered - 1
 	if attemptNum < 0 {
 		attemptNum = 0
 	}
-	backoff, backoffDelay := parseBackoffFuncAndDelay(config)
-	return backoff(attemptNum, backoffDelay)
-}
-
-type backoffFunc func(attemptNum int, delayDuration time.Duration) time.Duration
-
-func LinearBackoff(attemptNum int, delayDuration time.Duration) time.Duration {
-	return delayDuration * time.Duration(attemptNum)
-}
-
-func ExpBackoff(attemptNum int, delayDuration time.Duration) time.Duration {
-	return delayDuration * time.Duration(math.Exp2(float64(attemptNum)))
-}
-
-func parseBackoffFuncAndDelay(config *kncloudevents.RetryConfig) (backoffFunc, time.Duration) {
-	var backoff backoffFunc
-	switch *config.BackoffPolicy {
-	case v1.BackoffPolicyExponential:
-		backoff = ExpBackoff
-	case v1.BackoffPolicyLinear:
-		backoff = LinearBackoff
-	}
-	// it should be validated at this point
-	delay, _ := period.Parse(*config.BackoffDelay)
-	backoffDelay, _ := delay.Duration()
-
-	return backoff, backoffDelay
+	return config.Backoff(attemptNum, nil)
 }

--- a/pkg/channel/jetstream/utils/consumerconfig_test.go
+++ b/pkg/channel/jetstream/utils/consumerconfig_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/eventing/pkg/kncloudevents"
+)
+
+func TestCalculateNakDelayUsesZeroBasedAttempt(t *testing.T) {
+	delay := "PT1S"
+	exponential := eventingduckv1.BackoffPolicyExponential
+	linear := eventingduckv1.BackoffPolicyLinear
+
+	newConfig := func(policy eventingduckv1.BackoffPolicyType) *kncloudevents.RetryConfig {
+		t.Helper()
+		return &kncloudevents.RetryConfig{
+			BackoffPolicy: &policy,
+			BackoffDelay:  &delay,
+		}
+	}
+
+	tests := []struct {
+		name         string
+		numDelivered int
+		config       *kncloudevents.RetryConfig
+		want         time.Duration
+	}{
+		{name: "first exponential retry", numDelivered: 1, config: newConfig(exponential), want: time.Second},
+		{name: "second exponential retry", numDelivered: 2, config: newConfig(exponential), want: 2 * time.Second},
+		{name: "fourth exponential retry", numDelivered: 4, config: newConfig(exponential), want: 8 * time.Second},
+		{name: "first linear retry", numDelivered: 1, config: newConfig(linear), want: 0},
+		{name: "second linear retry", numDelivered: 2, config: newConfig(linear), want: time.Second},
+		{name: "fourth linear retry", numDelivered: 4, config: newConfig(linear), want: 3 * time.Second},
+		{name: "zero delivery number is clamped", numDelivered: 0, config: newConfig(exponential), want: time.Second},
+		{name: "negative delivery number is clamped", numDelivered: -1, config: newConfig(exponential), want: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalculateNakDelayForRetryNumber(tt.numDelivered, tt.config); got != tt.want {
+				t.Errorf("CalculateNakDelayForRetryNumber() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/channel/jetstream/utils/consumerconfig_test.go
+++ b/pkg/channel/jetstream/utils/consumerconfig_test.go
@@ -24,17 +24,23 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 )
 
-func TestCalculateNakDelayUsesZeroBasedAttempt(t *testing.T) {
+func TestCalculateNakDelayForRetryNumber(t *testing.T) {
 	delay := "PT1S"
+	backoffMax := "PT2S"
 	exponential := eventingduckv1.BackoffPolicyExponential
 	linear := eventingduckv1.BackoffPolicyLinear
 
-	newConfig := func(policy eventingduckv1.BackoffPolicyType) *kncloudevents.RetryConfig {
+	newConfig := func(policy eventingduckv1.BackoffPolicyType, max *string) *kncloudevents.RetryConfig {
 		t.Helper()
-		return &kncloudevents.RetryConfig{
+		config, err := kncloudevents.RetryConfigFromDeliverySpec(eventingduckv1.DeliverySpec{
 			BackoffPolicy: &policy,
 			BackoffDelay:  &delay,
+			BackoffMax:    max,
+		})
+		if err != nil {
+			t.Fatal(err)
 		}
+		return &config
 	}
 
 	tests := []struct {
@@ -43,14 +49,17 @@ func TestCalculateNakDelayUsesZeroBasedAttempt(t *testing.T) {
 		config       *kncloudevents.RetryConfig
 		want         time.Duration
 	}{
-		{name: "first exponential retry", numDelivered: 1, config: newConfig(exponential), want: time.Second},
-		{name: "second exponential retry", numDelivered: 2, config: newConfig(exponential), want: 2 * time.Second},
-		{name: "fourth exponential retry", numDelivered: 4, config: newConfig(exponential), want: 8 * time.Second},
-		{name: "first linear retry", numDelivered: 1, config: newConfig(linear), want: 0},
-		{name: "second linear retry", numDelivered: 2, config: newConfig(linear), want: time.Second},
-		{name: "fourth linear retry", numDelivered: 4, config: newConfig(linear), want: 3 * time.Second},
-		{name: "zero delivery number is clamped", numDelivered: 0, config: newConfig(exponential), want: time.Second},
-		{name: "negative delivery number is clamped", numDelivered: -1, config: newConfig(exponential), want: time.Second},
+		{name: "nil config", numDelivered: 1, want: 0},
+		{name: "config without backoff", numDelivered: 1, config: &kncloudevents.RetryConfig{}, want: 0},
+		{name: "first exponential retry", numDelivered: 1, config: newConfig(exponential, &backoffMax), want: time.Second},
+		{name: "second exponential retry", numDelivered: 2, config: newConfig(exponential, &backoffMax), want: 2 * time.Second},
+		{name: "capped exponential retry", numDelivered: 4, config: newConfig(exponential, &backoffMax), want: 2 * time.Second},
+		{name: "first linear retry", numDelivered: 1, config: newConfig(linear, &backoffMax), want: 0},
+		{name: "second linear retry", numDelivered: 2, config: newConfig(linear, &backoffMax), want: time.Second},
+		{name: "capped linear retry", numDelivered: 4, config: newConfig(linear, &backoffMax), want: 2 * time.Second},
+		{name: "zero delivery number is clamped", numDelivered: 0, config: newConfig(exponential, &backoffMax), want: time.Second},
+		{name: "negative delivery number is clamped", numDelivered: -1, config: newConfig(exponential, &backoffMax), want: time.Second},
+		{name: "huge retry stays capped", numDelivered: int(^uint(0) >> 1), config: newConfig(exponential, &backoffMax), want: 2 * time.Second},
 	}
 
 	for _, tt := range tests {

--- a/pkg/channel/jetstream/utils/consumerconfig_test.go
+++ b/pkg/channel/jetstream/utils/consumerconfig_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -27,15 +28,18 @@ import (
 func TestCalculateNakDelayForRetryNumber(t *testing.T) {
 	delay := "PT1S"
 	backoffMax := "PT2S"
+	retryAfterMax := "PT3S"
+	retryAfterDisabled := "PT0S"
 	exponential := eventingduckv1.BackoffPolicyExponential
 	linear := eventingduckv1.BackoffPolicyLinear
 
-	newConfig := func(policy eventingduckv1.BackoffPolicyType, max *string) *kncloudevents.RetryConfig {
+	newConfig := func(policy eventingduckv1.BackoffPolicyType, max, retryAfterMax *string) *kncloudevents.RetryConfig {
 		t.Helper()
 		config, err := kncloudevents.RetryConfigFromDeliverySpec(eventingduckv1.DeliverySpec{
 			BackoffPolicy: &policy,
 			BackoffDelay:  &delay,
 			BackoffMax:    max,
+			RetryAfterMax: retryAfterMax,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -47,26 +51,110 @@ func TestCalculateNakDelayForRetryNumber(t *testing.T) {
 		name         string
 		numDelivered int
 		config       *kncloudevents.RetryConfig
+		response     *http.Response
 		want         time.Duration
 	}{
 		{name: "nil config", numDelivered: 1, want: 0},
 		{name: "config without backoff", numDelivered: 1, config: &kncloudevents.RetryConfig{}, want: 0},
-		{name: "first exponential retry", numDelivered: 1, config: newConfig(exponential, &backoffMax), want: time.Second},
-		{name: "second exponential retry", numDelivered: 2, config: newConfig(exponential, &backoffMax), want: 2 * time.Second},
-		{name: "capped exponential retry", numDelivered: 4, config: newConfig(exponential, &backoffMax), want: 2 * time.Second},
-		{name: "first linear retry", numDelivered: 1, config: newConfig(linear, &backoffMax), want: 0},
-		{name: "second linear retry", numDelivered: 2, config: newConfig(linear, &backoffMax), want: time.Second},
-		{name: "capped linear retry", numDelivered: 4, config: newConfig(linear, &backoffMax), want: 2 * time.Second},
-		{name: "zero delivery number is clamped", numDelivered: 0, config: newConfig(exponential, &backoffMax), want: time.Second},
-		{name: "negative delivery number is clamped", numDelivered: -1, config: newConfig(exponential, &backoffMax), want: time.Second},
-		{name: "huge retry stays capped", numDelivered: int(^uint(0) >> 1), config: newConfig(exponential, &backoffMax), want: 2 * time.Second},
+		{name: "first exponential retry", numDelivered: 1, config: newConfig(exponential, &backoffMax, nil), want: time.Second},
+		{name: "second exponential retry", numDelivered: 2, config: newConfig(exponential, &backoffMax, nil), want: 2 * time.Second},
+		{name: "capped exponential retry", numDelivered: 4, config: newConfig(exponential, &backoffMax, nil), want: 2 * time.Second},
+		{name: "first linear retry", numDelivered: 1, config: newConfig(linear, &backoffMax, nil), want: 0},
+		{name: "second linear retry", numDelivered: 2, config: newConfig(linear, &backoffMax, nil), want: time.Second},
+		{name: "capped linear retry", numDelivered: 4, config: newConfig(linear, &backoffMax, nil), want: 2 * time.Second},
+		{name: "zero delivery number is clamped", numDelivered: 0, config: newConfig(exponential, &backoffMax, nil), want: time.Second},
+		{name: "negative delivery number is clamped", numDelivered: -1, config: newConfig(exponential, &backoffMax, nil), want: time.Second},
+		{name: "huge retry stays capped", numDelivered: int(^uint(0) >> 1), config: newConfig(exponential, &backoffMax, nil), want: 2 * time.Second},
+		{
+			name:         "429 retry after is capped independently",
+			numDelivered: 1,
+			config:       newConfig(exponential, &backoffMax, &retryAfterMax),
+			response:     retryAfterResponse(http.StatusTooManyRequests, "5"),
+			want:         3 * time.Second,
+		},
+		{
+			name:         "503 retry after is honored",
+			numDelivered: 1,
+			config:       newConfig(exponential, &backoffMax, &retryAfterMax),
+			response:     retryAfterResponse(http.StatusServiceUnavailable, "2"),
+			want:         2 * time.Second,
+		},
+		{
+			name:         "backoff max does not cap retry after",
+			numDelivered: 1,
+			config:       newConfig(exponential, &backoffMax, &retryAfterMax),
+			response:     retryAfterResponse(http.StatusTooManyRequests, "3"),
+			want:         3 * time.Second,
+		},
+		{
+			name:         "larger normal backoff wins",
+			numDelivered: 4,
+			config:       newConfig(exponential, nil, &retryAfterMax),
+			response:     retryAfterResponse(http.StatusTooManyRequests, "2"),
+			want:         8 * time.Second,
+		},
+		{
+			name:         "retry after is ignored without opt in",
+			numDelivered: 1,
+			config:       newConfig(exponential, &backoffMax, nil),
+			response:     retryAfterResponse(http.StatusTooManyRequests, "5"),
+			want:         time.Second,
+		},
+		{
+			name:         "zero retry after max opts out",
+			numDelivered: 1,
+			config:       newConfig(exponential, &backoffMax, &retryAfterDisabled),
+			response:     retryAfterResponse(http.StatusTooManyRequests, "5"),
+			want:         time.Second,
+		},
+		{
+			name:         "retry after is ignored for other response codes",
+			numDelivered: 1,
+			config:       newConfig(exponential, &backoffMax, &retryAfterMax),
+			response:     retryAfterResponse(http.StatusInternalServerError, "5"),
+			want:         time.Second,
+		},
+		{
+			name:         "invalid retry after falls back to normal backoff",
+			numDelivered: 1,
+			config:       newConfig(exponential, &backoffMax, &retryAfterMax),
+			response:     retryAfterResponse(http.StatusTooManyRequests, "invalid"),
+			want:         time.Second,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CalculateNakDelayForRetryNumber(tt.numDelivered, tt.config); got != tt.want {
+			if got := CalculateNakDelayForRetryNumber(tt.numDelivered, tt.config, tt.response); got != tt.want {
 				t.Errorf("CalculateNakDelayForRetryNumber() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCalculateNakDelayForRetryNumberWithHTTPDate(t *testing.T) {
+	delay := "PT1S"
+	retryAfterMax := "PT10S"
+	exponential := eventingduckv1.BackoffPolicyExponential
+	config, err := kncloudevents.RetryConfigFromDeliverySpec(eventingduckv1.DeliverySpec{
+		BackoffPolicy: &exponential,
+		BackoffDelay:  &delay,
+		RetryAfterMax: &retryAfterMax,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := retryAfterResponse(http.StatusServiceUnavailable, time.Now().Add(5*time.Second).UTC().Format(http.TimeFormat))
+	got := CalculateNakDelayForRetryNumber(1, &config, response)
+	if got < 3*time.Second || got > 5*time.Second {
+		t.Fatalf("CalculateNakDelayForRetryNumber() = %v, want between 3s and 5s", got)
+	}
+}
+
+func retryAfterResponse(status int, retryAfter string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Retry-After": []string{retryAfter}},
 	}
 }

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -21,8 +21,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/eventing-natss/pkg/apis/messaging/v1alpha1"
+	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/webhook/resourcesemantics"
 	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
@@ -62,9 +64,12 @@ func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) 
 }
 
 func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"))
+	featureStore.WatchConfigs(cmw)
+
 	// A function that infuses the context passed to ConvertTo/ConvertFrom/SetDefaults with custom metadata.
 	ctxFunc := func(ctx context.Context) context.Context {
-		return ctx
+		return featureStore.ToContext(ctx)
 	}
 	return validation.NewAdmissionController(ctx,
 

--- a/test/experimental/backoff_max_test.go
+++ b/test/experimental/backoff_max_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experimental
+
+import (
+	"testing"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing-natss/test/experimental/features/delivery"
+)
+
+func TestBackoffMax(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithObservabilityConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, delivery.BackoffMaxBrokerToSink())
+	env.Test(ctx, t, delivery.BackoffMaxChannelToSink())
+}

--- a/test/experimental/config/features.yaml
+++ b/test/experimental/config/features.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-eventing
+  labels:
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+data:
+  kreference-group: "enabled"
+  delivery-retryafter: "enabled"
+  delivery-backoff-max: "enabled"
+  delivery-timeout: "enabled"
+  eventtype-auto-create: "enabled"

--- a/test/experimental/features/delivery/backoff_max.go
+++ b/test/experimental/features/delivery/backoff_max.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delivery
+
+import (
+	"net/http"
+	"time"
+
+	"k8s.io/utils/ptr"
+	"knative.dev/reconciler-test/pkg/feature"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+)
+
+// BackoffMaxBrokerToSink verifies that BackoffMax caps Broker retries.
+func BackoffMaxBrokerToSink() *feature.Feature {
+	return backoffMax("Broker delivery backoff maximum", brokerRoute)
+}
+
+// BackoffMaxChannelToSink verifies that a Channel default BackoffMax caps Subscription retries.
+func BackoffMaxChannelToSink() *feature.Feature {
+	return backoffMax("Channel delivery backoff maximum", channelRoute)
+}
+
+func backoffMax(name string, route deliveryRoute) *feature.Feature {
+	backoffPolicy := eventingduckv1.BackoffPolicyExponential
+	return newDeliveryFeature(name, "backoff-max", route, retryBehavior{
+		retries:      4,
+		responseCode: http.StatusServiceUnavailable,
+		delivery: &eventingduckv1.DeliverySpec{
+			Retry:         ptr.To(int32(4)),
+			BackoffPolicy: &backoffPolicy,
+			BackoffDelay:  ptr.To("PT1S"),
+			BackoffMax:    ptr.To("PT2S"),
+		},
+		expectedIntervals: []time.Duration{time.Second, 2 * time.Second, 2 * time.Second, 2 * time.Second},
+		rejectedStep:      "receiver rejects the first four deliveries",
+		receivedStep:      "receiver accepts the fifth delivery",
+		timingStep:        "retry delay stops growing at two seconds",
+	})
+}

--- a/test/experimental/features/delivery/feature.go
+++ b/test/experimental/features/delivery/feature.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delivery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+
+	natssv1alpha1 "knative.dev/eventing-natss/pkg/apis/messaging/v1alpha1"
+	brokerconstants "knative.dev/eventing-natss/pkg/broker/constants"
+	natssclient "knative.dev/eventing-natss/pkg/client/injection/client"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+)
+
+var (
+	brokerGVR       = eventingv1.SchemeGroupVersion.WithResource("brokers")
+	triggerGVR      = eventingv1.SchemeGroupVersion.WithResource("triggers")
+	subscriptionGVR = messagingv1.SchemeGroupVersion.WithResource("subscriptions")
+	natsChannelGVR  = natssv1alpha1.SchemeGroupVersion.WithResource("natsjetstreamchannels")
+	serviceGVR      = corev1.SchemeGroupVersion.WithResource("services")
+)
+
+type deliveryRoute int
+
+const (
+	brokerRoute deliveryRoute = iota
+	channelRoute
+)
+
+type retryBehavior struct {
+	retries           int32
+	responseCode      int
+	responseHeaders   map[string]string
+	delivery          *eventingduckv1.DeliverySpec
+	expectedIntervals []time.Duration
+	rejectedStep      string
+	receivedStep      string
+	timingStep        string
+}
+
+func newDeliveryFeature(name, resourcePrefix string, route deliveryRoute, behavior retryBehavior) *feature.Feature {
+	receiverName := feature.MakeRandomK8sName(resourcePrefix + "-receiver")
+	senderName := feature.MakeRandomK8sName(resourcePrefix + "-sender")
+	event := cetest.FullEvent()
+
+	receiverOptions := []eventshub.EventsHubOption{
+		eventshub.StartReceiver,
+		eventshub.DropFirstN(uint(behavior.retries)),
+		eventshub.DropEventsResponseCode(behavior.responseCode),
+	}
+	if len(behavior.responseHeaders) > 0 {
+		receiverOptions = append(receiverOptions, eventshub.DropEventsResponseHeaders(behavior.responseHeaders))
+	}
+
+	f := feature.NewFeatureNamed(name)
+	f.Setup("install receiver", eventshub.Install(receiverName, receiverOptions...))
+
+	var target schema.GroupVersionResource
+	var targetName string
+	switch route {
+	case brokerRoute:
+		target = brokerGVR
+		targetName = feature.MakeRandomK8sName(resourcePrefix + "-broker")
+		triggerName := feature.MakeRandomK8sName(resourcePrefix + "-trigger")
+		f.Setup("install broker", installBroker(targetName))
+		f.Setup("install trigger", installTrigger(targetName, triggerName, receiverName, behavior.delivery))
+		f.Requirement("receiver is addressable", k8s.IsAddressable(serviceGVR, receiverName, time.Second, time.Minute))
+		f.Requirement("broker is ready", k8s.IsReady(brokerGVR, targetName, time.Second, 3*time.Minute))
+		f.Requirement("trigger is ready", k8s.IsReady(triggerGVR, triggerName, time.Second, 3*time.Minute))
+	case channelRoute:
+		target = natsChannelGVR
+		targetName = feature.MakeRandomK8sName(resourcePrefix + "-channel")
+		subscriptionName := feature.MakeRandomK8sName(resourcePrefix + "-subscription")
+		f.Setup("install channel", installChannel(targetName, behavior.delivery))
+		f.Setup("install subscription", installSubscription(targetName, subscriptionName, receiverName))
+		f.Requirement("receiver is addressable", k8s.IsAddressable(serviceGVR, receiverName, time.Second, time.Minute))
+		f.Requirement("channel is ready", k8s.IsReady(natsChannelGVR, targetName, time.Second, 3*time.Minute))
+		f.Requirement("subscription is ready", k8s.IsReady(subscriptionGVR, subscriptionName, time.Second, 3*time.Minute))
+	default:
+		panic(fmt.Sprintf("unsupported delivery route %d", route))
+	}
+
+	f.Assert("send event", eventshub.Install(
+		senderName,
+		eventshub.StartSenderToResource(target, targetName),
+		eventshub.InputEvent(event),
+	))
+	f.Assert(behavior.rejectedStep, assertExact(receiverName, int(behavior.retries), eventWithKind(event.ID(), eventshub.EventRejected)))
+	f.Assert(behavior.receivedStep, assertExact(receiverName, 1, eventWithKind(event.ID(), eventshub.EventReceived)))
+	f.Assert(behavior.timingStep, assertExact(receiverName, int(behavior.retries)+1, deliveriesFollowIntervals(event.ID(), behavior.expectedIntervals)))
+
+	return f
+}
+
+func assertExact(receiverName string, count int, matcher eventshub.EventInfoMatcher) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		eventshub.StoreFromContext(ctx, receiverName).AssertExact(ctx, t, count, matcher)
+	}
+}
+
+func installBroker(name string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		namespace := environment.FromContext(ctx).Namespace()
+		_, err := eventingclient.Get(ctx).EventingV1().Brokers(namespace).Create(ctx, &eventingv1.Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					eventingv1.BrokerClassAnnotationKey: brokerconstants.BrokerClassName,
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+}
+
+func installTrigger(brokerName, triggerName, receiverName string, delivery *eventingduckv1.DeliverySpec) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		namespace := environment.FromContext(ctx).Namespace()
+		_, err := eventingclient.Get(ctx).EventingV1().Triggers(namespace).Create(ctx, &eventingv1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{Name: triggerName, Namespace: namespace},
+			Spec: eventingv1.TriggerSpec{
+				Broker: brokerName,
+				Subscriber: duckv1.Destination{Ref: &duckv1.KReference{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+					Name:       receiverName,
+				}},
+				Delivery: delivery,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+}
+
+func installChannel(name string, delivery *eventingduckv1.DeliverySpec) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		namespace := environment.FromContext(ctx).Namespace()
+		_, err := natssclient.Get(ctx).MessagingV1alpha1().NatsJetStreamChannels(namespace).Create(ctx, &natssv1alpha1.NatsJetStreamChannel{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: natssv1alpha1.NatsJetStreamChannelSpec{
+				ChannelableSpec: eventingduckv1.ChannelableSpec{Delivery: delivery},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+}
+
+func installSubscription(channelName, subscriptionName, receiverName string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		namespace := environment.FromContext(ctx).Namespace()
+		_, err := eventingclient.Get(ctx).MessagingV1().Subscriptions(namespace).Create(ctx, &messagingv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{Name: subscriptionName, Namespace: namespace},
+			Spec: messagingv1.SubscriptionSpec{
+				Channel: duckv1.KReference{
+					APIVersion: natssv1alpha1.SchemeGroupVersion.String(),
+					Kind:       "NatsJetStreamChannel",
+					Name:       channelName,
+				},
+				Subscriber: &duckv1.Destination{Ref: &duckv1.KReference{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+					Name:       receiverName,
+				}},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+}

--- a/test/experimental/features/delivery/feature_test.go
+++ b/test/experimental/features/delivery/feature_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delivery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func TestFeaturesRunSenderAfterReadiness(t *testing.T) {
+	tests := []struct {
+		name         string
+		build        func() *feature.Feature
+		readiness    []string
+		resultChecks []string
+	}{
+		{
+			name:      "Broker BackoffMax",
+			build:     BackoffMaxBrokerToSink,
+			readiness: []string{"receiver is addressable", "broker is ready", "trigger is ready"},
+			resultChecks: []string{
+				"receiver rejects the first four deliveries",
+				"receiver accepts the fifth delivery",
+				"retry delay stops growing at two seconds",
+			},
+		},
+		{
+			name:      "Channel BackoffMax",
+			build:     BackoffMaxChannelToSink,
+			readiness: []string{"receiver is addressable", "channel is ready", "subscription is ready"},
+			resultChecks: []string{
+				"receiver rejects the first four deliveries",
+				"receiver accepts the fifth delivery",
+				"retry delay stops growing at two seconds",
+			},
+		},
+		{
+			name:      "Broker RetryAfterMax",
+			build:     RetryAfterMaxBrokerToSink,
+			readiness: []string{"receiver is addressable", "broker is ready", "trigger is ready"},
+			resultChecks: []string{
+				"receiver rejects the first two deliveries",
+				"receiver accepts the third delivery",
+				"Retry-After delay is capped at two seconds",
+			},
+		},
+		{
+			name:      "Channel RetryAfterMax",
+			build:     RetryAfterMaxChannelToSink,
+			readiness: []string{"receiver is addressable", "channel is ready", "subscription is ready"},
+			resultChecks: []string{
+				"receiver rejects the first two deliveries",
+				"receiver accepts the third delivery",
+				"Retry-After delay is capped at two seconds",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timings := make(map[string]feature.Timing)
+			for _, step := range tt.build().Steps {
+				timings[step.Name] = step.T
+			}
+
+			for _, name := range tt.readiness {
+				timing, ok := timings[name]
+				require.Truef(t, ok, "step %q not found", name)
+				require.Equal(t, feature.Requirement, timing)
+			}
+
+			for _, name := range append([]string{"send event"}, tt.resultChecks...) {
+				timing, ok := timings[name]
+				require.Truef(t, ok, "step %q not found", name)
+				require.Equal(t, feature.Assert, timing)
+			}
+		})
+	}
+}

--- a/test/experimental/features/delivery/matchers.go
+++ b/test/experimental/features/delivery/matchers.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delivery
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"knative.dev/reconciler-test/pkg/eventshub"
+)
+
+func eventWithKind(id string, kind eventshub.EventKind) eventshub.EventInfoMatcher {
+	return func(info eventshub.EventInfo) error {
+		if info.Event == nil {
+			return fmt.Errorf("received event is nil")
+		}
+		if info.Event.ID() != id {
+			return fmt.Errorf("received event ID %q, expected %q", info.Event.ID(), id)
+		}
+		if info.Kind != kind {
+			return fmt.Errorf("received event kind %q, expected %q", info.Kind, kind)
+		}
+		return nil
+	}
+}
+
+func deliveriesFollowIntervals(id string, expected []time.Duration) eventshub.EventInfoMatcher {
+	type deliveryKey struct {
+		kind     eventshub.EventKind
+		sequence uint64
+	}
+
+	var mu sync.Mutex
+	seen := make(map[deliveryKey]eventshub.EventInfo, len(expected)+1)
+
+	return func(info eventshub.EventInfo) error {
+		if info.Event == nil {
+			return fmt.Errorf("received event is nil")
+		}
+		if info.Event.ID() != id {
+			return fmt.Errorf("received event ID %q, expected %q", info.Event.ID(), id)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		seen[deliveryKey{kind: info.Kind, sequence: info.Sequence}] = info
+		if len(seen) < len(expected)+1 {
+			return nil
+		}
+
+		deliveries := make([]eventshub.EventInfo, 0, len(seen))
+		for _, delivery := range seen {
+			deliveries = append(deliveries, delivery)
+		}
+		sort.Slice(deliveries, func(i, j int) bool {
+			return deliveries[i].Time.Before(deliveries[j].Time)
+		})
+
+		for i, wait := range expected {
+			actual := deliveries[i+1].Time.Sub(deliveries[i].Time)
+			if actual < wait-500*time.Millisecond || actual > wait+3*time.Second {
+				return fmt.Errorf("delivery %d waited %s, expected %s", i+2, actual, wait)
+			}
+		}
+		return nil
+	}
+}

--- a/test/experimental/features/delivery/matchers_test.go
+++ b/test/experimental/features/delivery/matchers_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delivery
+
+import (
+	"testing"
+	"time"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/stretchr/testify/require"
+	"knative.dev/reconciler-test/pkg/eventshub"
+)
+
+func TestEventWithKind(t *testing.T) {
+	event := cetest.FullEvent()
+	matcher := eventWithKind(event.ID(), eventshub.EventReceived)
+
+	require.NoError(t, matcher(eventshub.EventInfo{Event: &event, Kind: eventshub.EventReceived}))
+	require.Error(t, matcher(eventshub.EventInfo{Kind: eventshub.EventReceived}))
+	require.Error(t, matcher(eventshub.EventInfo{Event: &event, Kind: eventshub.EventRejected}))
+
+	other := cetest.FullEvent()
+	other.SetID("other")
+	require.Error(t, matcher(eventshub.EventInfo{Event: &other, Kind: eventshub.EventReceived}))
+}
+
+func TestDeliveriesFollowIntervals(t *testing.T) {
+	event := cetest.FullEvent()
+	tests := []struct {
+		name      string
+		expected  []time.Duration
+		intervals []time.Duration
+		wantErr   bool
+	}{
+		{
+			name:      "capped exponential backoff",
+			expected:  []time.Duration{time.Second, 2 * time.Second, 2 * time.Second, 2 * time.Second},
+			intervals: []time.Duration{time.Second, 2 * time.Second, 2 * time.Second, 2 * time.Second},
+		},
+		{
+			name:      "uncapped exponential backoff",
+			expected:  []time.Duration{time.Second, 2 * time.Second, 2 * time.Second, 2 * time.Second},
+			intervals: []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second},
+			wantErr:   true,
+		},
+		{
+			name:      "capped Retry-After",
+			expected:  []time.Duration{2 * time.Second, 2 * time.Second},
+			intervals: []time.Duration{2 * time.Second, 2 * time.Second},
+		},
+		{
+			name:      "uncapped Retry-After",
+			expected:  []time.Duration{2 * time.Second, 2 * time.Second},
+			intervals: []time.Duration{6 * time.Second, 6 * time.Second},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := deliveriesFollowIntervals(event.ID(), tt.expected)
+			receivedAt := time.Unix(0, 0)
+			var gotErr error
+			for i := 0; i <= len(tt.intervals); i++ {
+				if i > 0 {
+					receivedAt = receivedAt.Add(tt.intervals[i-1])
+				}
+
+				kind := eventshub.EventRejected
+				sequence := uint64(i + 1)
+				if i == len(tt.intervals) {
+					kind = eventshub.EventReceived
+					sequence = 1
+				}
+				gotErr = matcher(eventshub.EventInfo{
+					Event:    &event,
+					Kind:     kind,
+					Time:     receivedAt,
+					Sequence: sequence,
+				})
+				if i < len(tt.intervals) {
+					require.NoError(t, gotErr)
+				}
+			}
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+		})
+	}
+}

--- a/test/experimental/features/delivery/retry_after.go
+++ b/test/experimental/features/delivery/retry_after.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delivery
+
+import (
+	"net/http"
+	"time"
+
+	"k8s.io/utils/ptr"
+	"knative.dev/reconciler-test/pkg/feature"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+)
+
+// RetryAfterMaxBrokerToSink verifies that RetryAfterMax caps Broker retries.
+func RetryAfterMaxBrokerToSink() *feature.Feature {
+	return retryAfterMax("Broker delivery Retry-After maximum", brokerRoute)
+}
+
+// RetryAfterMaxChannelToSink verifies that a Channel default RetryAfterMax caps Subscription retries.
+func RetryAfterMaxChannelToSink() *feature.Feature {
+	return retryAfterMax("Channel delivery Retry-After maximum", channelRoute)
+}
+
+func retryAfterMax(name string, route deliveryRoute) *feature.Feature {
+	backoffPolicy := eventingduckv1.BackoffPolicyExponential
+	return newDeliveryFeature(name, "retry-after-max", route, retryBehavior{
+		retries:         2,
+		responseCode:    http.StatusTooManyRequests,
+		responseHeaders: map[string]string{"Retry-After": "6"},
+		delivery: &eventingduckv1.DeliverySpec{
+			Retry:         ptr.To(int32(2)),
+			BackoffPolicy: &backoffPolicy,
+			BackoffDelay:  ptr.To("PT1S"),
+			BackoffMax:    ptr.To("PT2S"),
+			RetryAfterMax: ptr.To("PT2S"),
+		},
+		expectedIntervals: []time.Duration{2 * time.Second, 2 * time.Second},
+		rejectedStep:      "receiver rejects the first two deliveries",
+		receivedStep:      "receiver accepts the third delivery",
+		timingStep:        "Retry-After delay is capped at two seconds",
+	})
+}

--- a/test/experimental/main_test.go
+++ b/test/experimental/main_test.go
@@ -1,0 +1,39 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experimental
+
+import (
+	"os"
+	"testing"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	// Link this first so the system namespace is defaulted before logstream
+	// initialization.
+	_ "knative.dev/eventing-natss/test/defaultsystem"
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+var global environment.GlobalEnvironment
+
+func TestMain(m *testing.M) {
+	global = environment.NewStandardGlobalEnvironment()
+	os.Exit(m.Run())
+}

--- a/test/experimental/retry_after_test.go
+++ b/test/experimental/retry_after_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experimental
+
+import (
+	"testing"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing-natss/test/experimental/features/delivery"
+)
+
+func TestRetryAfterMax(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithObservabilityConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, delivery.RetryAfterMaxBrokerToSink())
+	env.Test(ctx, t, delivery.RetryAfterMaxChannelToSink())
+}


### PR DESCRIPTION
Related upstream: [knative/eventing#9278](https://github.com/knative/eventing/issues/9278), implemented by [knative/eventing#9279](https://github.com/knative/eventing/pull/9279).

## Proposed Changes

This PR adds native NATS support for Eventing's experimental `DeliverySpec.backoffMax`. The [Eventing revision selected by `go.mod`](https://github.com/knative-extensions/eventing-natss/blob/f85abceb385bf1c1866e046fd744a33475a93c3d/go.mod#L32) is the merge commit of knative/eventing#9279, which defines [`backoffMax` and `retryAfterMax`](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/pkg/apis/duck/v1/delivery_types.go#L65-L99) and their [feature-gated validation](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/pkg/apis/duck/v1/delivery_types.go#L150-L179).

- Apply `backoffMax` to Broker and Trigger delivery, and expose it through `NatsJetStreamChannel` defaults and subscriber delivery.
- Run the complete upstream `DeliverySpec` validation with Eventing feature flags available to the channel webhook.
- Map JetStream's one-based delivery count to Eventing's zero-based backoff attempt, and pass subscriber response status and headers into Eventing's backoff calculation.

## Retry behavior

| Field | Controls |
|---|---|
| `backoffMax` | Delays calculated from `backoffDelay` and `backoffPolicy` |
| `retryAfterMax` | Delays requested by `Retry-After` on HTTP 429 and 503 responses |

The limits are independent. Eventing caps each delay separately and [uses the larger result](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/pkg/kncloudevents/retries.go#L280-L300). Operators enable `delivery-backoff-max`, and additionally enable `delivery-retryafter` when using `retryAfterMax`.

## Tests

Unit tests cover retry numbering, delivery propagation, feature-gated validation, and response-aware delay calculation. Experimental E2E tests cover `backoffMax` and `retryAfterMax` through both the NATS Broker and `NatsJetStreamChannel`, following Eventing's upstream [`backoffMax` scenario](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/test/experimental/features/backoff_max/channel.go#L44-L75) and [`Retry-After` assertions](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/test/experimental/features/retry_after/channel.go#L70-L108).

The KinD workflow follows Eventing's [Kubernetes and suite matrix](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/.github/workflows/kind-e2e.yaml#L35-L43), [Kind setup](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/.github/workflows/kind-e2e.yaml#L77-L83), and [experimental-suite execution](https://github.com/knative/eventing/blob/973bbbc1f791c274578360917c7d492828b48cb0/.github/workflows/kind-e2e.yaml#L103-L119).

| Eventing installation | Suites | Kubernetes |
|---|---|---|
| `knative-v1.23.0` release | Regular E2E | `v1.34.x`, `v1.35.x` |
| Revision selected by `go.mod` | Regular and experimental E2E | `v1.34.x`, `v1.35.x` |

**Release Note**

```release-note
🎁 Add experimental DeliverySpec.backoffMax support to native NATS Broker and NatsJetStreamChannel delivery, and honor retryAfterMax when scheduling JetStream redeliveries.
```

**Docs**

Provider documentation is included for [Broker delivery](https://github.com/knative-extensions/eventing-natss/blob/f85abceb385bf1c1866e046fd744a33475a93c3d/docs/broker.md#L164-L193) and [`NatsJetStreamChannel` delivery](https://github.com/knative-extensions/eventing-natss/blob/f85abceb385bf1c1866e046fd744a33475a93c3d/docs/jetstream.md#L152-L192). Upstream user documentation is tracked in [knative/docs#6686](https://github.com/knative/docs/pull/6686).
