### PR TITLE
Support topology spread constraints for broker filters

### DIFF
--- a/pkg/broker/config/config_test.go
+++ b/pkg/broker/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nats-io/nats.go"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"knative.dev/eventing-natss/pkg/apis/messaging/v1alpha1"
 )
@@ -227,6 +228,31 @@ func TestGetConfigFromAnnotation(t *testing.T) {
 			want: &NatsJetStreamBrokerConfig{
 				Stream: &v1alpha1.StreamConfig{
 					Replicas: 3,
+				},
+			},
+		},
+		{
+			name: "filter topology spread constraints",
+			annotations: map[string]string{
+				BrokerConfigAnnotation: `{"filter":{"topologySpreadConstraints":[{"maxSkew":1,"minDomains":2,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"DoNotSchedule","labelSelector":{"matchLabels":{"eventing.knative.dev/broker":"example-broker","eventing.knative.dev/role":"filter"}},"matchLabelKeys":["pod-template-hash"]}]}}`,
+			},
+			want: &NatsJetStreamBrokerConfig{
+				Filter: &DeploymentTemplate{
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							MinDomains:        ptr.To[int32](2),
+							TopologyKey:       corev1.LabelHostname,
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"eventing.knative.dev/broker": "example-broker",
+									"eventing.knative.dev/role":   "filter",
+								},
+							},
+							MatchLabelKeys: []string{"pod-template-hash"},
+						},
+					},
 				},
 			},
 		},
@@ -463,5 +489,38 @@ func TestBrokerConfigAnnotationRoundTrip(t *testing.T) {
 
 	if diff := cmp.Diff(original, got); diff != "" {
 		t.Errorf("Round-trip mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDeploymentTemplateDeepCopyTopologySpreadConstraints(t *testing.T) {
+	original := &DeploymentTemplate{
+		TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				MinDomains:        ptr.To[int32](2),
+				TopologyKey:       corev1.LabelHostname,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "example-filter"},
+				},
+				MatchLabelKeys: []string{"pod-template-hash"},
+			},
+		},
+	}
+
+	got := original.DeepCopy()
+	got.TopologySpreadConstraints[0].LabelSelector.MatchLabels["app"] = "changed"
+	got.TopologySpreadConstraints[0].MatchLabelKeys[0] = "changed"
+	*got.TopologySpreadConstraints[0].MinDomains = 3
+
+	constraint := original.TopologySpreadConstraints[0]
+	if constraint.LabelSelector.MatchLabels["app"] != "example-filter" {
+		t.Error("DeepCopy mutated the original label selector")
+	}
+	if constraint.MatchLabelKeys[0] != "pod-template-hash" {
+		t.Error("DeepCopy mutated the original matchLabelKeys")
+	}
+	if *constraint.MinDomains != 2 {
+		t.Error("DeepCopy mutated the original minDomains")
 	}
 }

--- a/pkg/broker/config/types.go
+++ b/pkg/broker/config/types.go
@@ -77,6 +77,10 @@ type DeploymentTemplate struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// TopologySpreadConstraints controls how pods are spread across topology domains.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
 	// Env defines additional environment variables for the container.
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`
@@ -179,6 +183,13 @@ func (in *DeploymentTemplate) DeepCopyInto(out *DeploymentTemplate) {
 		in, out := &in.Affinity, &out.Affinity
 		*out = new(corev1.Affinity)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]corev1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env

--- a/pkg/broker/controller/resources/filter.go
+++ b/pkg/broker/controller/resources/filter.go
@@ -64,6 +64,7 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 	// Pod spec customization
 	var nodeSelector map[string]string
 	var affinity *corev1.Affinity
+	var topologySpreadConstraints []corev1.TopologySpreadConstraint
 	var resources corev1.ResourceRequirements
 
 	// Apply template if provided
@@ -89,6 +90,9 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 		if args.Template.Affinity != nil {
 			affinity = args.Template.Affinity
 		}
+		if args.Template.TopologySpreadConstraints != nil {
+			topologySpreadConstraints = args.Template.TopologySpreadConstraints
+		}
 		resources = args.Template.Resources
 	}
 
@@ -111,9 +115,10 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: args.ServiceAccountName,
-					NodeSelector:       nodeSelector,
-					Affinity:           affinity,
+					ServiceAccountName:        args.ServiceAccountName,
+					NodeSelector:              nodeSelector,
+					Affinity:                  affinity,
+					TopologySpreadConstraints: topologySpreadConstraints,
 					Containers: []corev1.Container{
 						{
 							Name:      FilterContainerName,

--- a/pkg/broker/controller/resources/filter_test.go
+++ b/pkg/broker/controller/resources/filter_test.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -248,6 +249,47 @@ func TestMakeFilterDeploymentWithNodeSelector(t *testing.T) {
 
 	if deployment.Spec.Template.Spec.NodeSelector["disktype"] != "ssd" {
 		t.Errorf("NodeSelector disktype = %v, want ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
+	}
+}
+
+func TestMakeFilterDeploymentWithTopologySpreadConstraints(t *testing.T) {
+	broker := &eventingv1.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-broker",
+			Namespace: "example-namespace",
+			UID:       "example-uid",
+		},
+	}
+
+	want := []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			MinDomains:        ptr.Int32(2),
+			TopologyKey:       corev1.LabelHostname,
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					BrokerLabelKey: "example-broker",
+					RoleLabelKey:   FilterRoleLabelValue,
+				},
+			},
+			MatchLabelKeys: []string{"pod-template-hash"},
+		},
+	}
+
+	deployment := MakeFilterDeployment(&FilterArgs{
+		Broker:             broker,
+		Image:              "registry.example.com/filter:latest",
+		ServiceAccountName: "example-service-account",
+		StreamName:         "EXAMPLE_STREAM",
+		NatsURL:            "nats://nats.example-namespace.svc.cluster.local:4222",
+		Template: &brokerconfig.DeploymentTemplate{
+			TopologySpreadConstraints: want,
+		},
+	})
+
+	if diff := cmp.Diff(want, deployment.Spec.Template.Spec.TopologySpreadConstraints); diff != "" {
+		t.Errorf("TopologySpreadConstraints mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
This adds topology spread constraints to the broker filter deployment template.

For example, a broker owner can spread filter replicas across nodes with the existing broker config annotation:

```yaml
metadata:
  name: example-broker
  annotations:
    natsjetstream.eventing.knative.dev/config: |
      {
        "filter": {
          "replicas": 3,
          "topologySpreadConstraints": [
            {
              "maxSkew": 1,
              "topologyKey": "kubernetes.io/hostname",
              "whenUnsatisfiable": "DoNotSchedule",
              "labelSelector": {
                "matchLabels": {
                  "eventing.knative.dev/broker": "example-broker",
                  "eventing.knative.dev/role": "filter"
                }
              }
            }
          ]
        }
      }
```

## Proposed Changes

- Pass `filter.topologySpreadConstraints` to the generated filter Deployment.

**Release Note**

```release-note
🎁 Broker filter pods can now use Kubernetes topology spread constraints configured through `filter.topologySpreadConstraints`.
```

**Docs**

Not included in this PR.