### PR TITLE
Publish to JetStream asynchronously in the broker ingress

### DIFF
--- a/pkg/broker/ingress/controller.go
+++ b/pkg/broker/ingress/controller.go
@@ -53,6 +53,14 @@ const (
 
 type envConfig struct {
 	Port int `envconfig:"PORT" default:"8080"`
+
+	// PublishTimeout bounds how long a request waits for a JetStream ack before
+	// returning 503 so the producer retries.
+	PublishTimeout time.Duration `envconfig:"PUBLISH_TIMEOUT" default:"10s"`
+
+	// PublishMaxInflight caps the number of outstanding (unacked) async publishes
+	// across the ingress. Reaching it applies backpressure to new requests.
+	PublishMaxInflight int `envconfig:"PUBLISH_MAX_INFLIGHT" default:"256"`
 }
 
 // NewController creates a new shared ingress controller
@@ -71,8 +79,9 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		logger.Fatalw("Failed to initialize NATS connection", zap.Error(err))
 	}
 
-	// Create JetStream context
-	js, err := natsConn.JetStream()
+	// Create JetStream context with a bounded async-publish window so the ingress
+	// can pipeline publishes while applying backpressure under load.
+	js, err := natsConn.JetStream(nats.PublishAsyncMaxPending(env.PublishMaxInflight))
 	if err != nil {
 		logger.Fatalw("Failed to create JetStream context", zap.Error(err))
 	}
@@ -81,8 +90,9 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 
 	// Create the shared ingress handler
 	handler := NewHandler(HandlerConfig{
-		Logger:    logger,
-		JetStream: js,
+		Logger:         logger,
+		JetStream:      js,
+		PublishTimeout: env.PublishTimeout,
 	})
 
 	// Get ConfigMap informer for watching contract changes

--- a/pkg/broker/ingress/handler.go
+++ b/pkg/broker/ingress/handler.go
@@ -19,8 +19,11 @@ package ingress
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	cejs "github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2"
 	ce "github.com/cloudevents/sdk-go/v2"
@@ -34,10 +37,23 @@ import (
 	"knative.dev/eventing-natss/pkg/tracing"
 )
 
+// defaultPublishTimeout bounds how long a request waits for a JetStream ack
+// before the producer is asked to retry.
+const defaultPublishTimeout = 30 * time.Second
+
+// errPublishUnavailable indicates the event could not be durably stored due to
+// backpressure or a transient JetStream error. It maps to HTTP 503 so the
+// producer retries; deduplication (nats.MsgId + the stream's duplicate window)
+// makes those retries safe.
+var errPublishUnavailable = errors.New("jetstream publish unavailable")
+
 // This is a shared handler that can route events to multiple brokers based on URL path
 type Handler struct {
 	logger *zap.SugaredLogger
 	js     nats.JetStreamContext
+
+	// publishTimeout bounds how long a request waits for a JetStream ack.
+	publishTimeout time.Duration
 
 	// Broker mappings protected by mutex
 	mu      sync.RWMutex
@@ -48,14 +64,23 @@ type Handler struct {
 type HandlerConfig struct {
 	Logger    *zap.SugaredLogger
 	JetStream nats.JetStreamContext
+
+	// PublishTimeout bounds how long a request waits for a JetStream ack before
+	// asking the producer to retry. Defaults to defaultPublishTimeout when unset.
+	PublishTimeout time.Duration
 }
 
 // NewHandler creates a new shared ingress handler
 func NewHandler(config HandlerConfig) *Handler {
+	publishTimeout := config.PublishTimeout
+	if publishTimeout <= 0 {
+		publishTimeout = defaultPublishTimeout
+	}
 	return &Handler{
-		logger:  config.Logger,
-		js:      config.JetStream,
-		brokers: make(map[string]contract.BrokerContract),
+		logger:         config.Logger,
+		js:             config.JetStream,
+		publishTimeout: publishTimeout,
+		brokers:        make(map[string]contract.BrokerContract),
 	}
 }
 
@@ -140,6 +165,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Publish to JetStream
 	if err := h.publishToJetStream(ctx, event, broker); err != nil {
+		if errors.Is(err, errPublishUnavailable) {
+			// Backpressure or transient JetStream error: ask the producer to
+			// retry rather than dropping the event as a hard failure.
+			logger.Warnw("JetStream publish unavailable, asking producer to retry", zap.Error(err))
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 		logger.Errorw("Failed to publish event to JetStream", zap.Error(err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -174,23 +207,46 @@ func (h *Handler) publishToJetStream(ctx context.Context, event *ce.Event, broke
 	// Add .events suffix to match the stream's subject pattern (publishSubject.>)
 	subject := broker.PublishSubject + ".events"
 
-	// Publish to JetStream with message ID for deduplication
-	_, err := h.js.Publish(subject, writer.Bytes(), nats.MsgId(string(eventID)))
+	// Publish asynchronously so many requests can be in flight at once, but wait
+	// for the ack before returning: a 202 is only sent once JetStream has
+	// durably stored the event. nats.MsgId enables server-side deduplication so
+	// a producer retry after a timeout does not double-store the event.
+	pubCtx, cancel := context.WithTimeout(ctx, h.publishTimeout)
+	defer cancel()
+
+	future, err := h.js.PublishAsync(subject, writer.Bytes(), nats.MsgId(string(eventID)))
 	if err != nil {
-		logger.Errorw("Failed to publish to JetStream",
+		// Immediate failure, e.g. the in-flight window is full (backpressure).
+		logger.Errorw("Failed to submit publish to JetStream",
 			zap.Error(err),
 			zap.String("subject", subject),
 			zap.String("event_id", string(eventID)),
 		)
-		return err
+		return fmt.Errorf("%w: %v", errPublishUnavailable, err)
 	}
 
-	logger.Debugw("Published event to JetStream",
-		zap.String("subject", subject),
-		zap.String("event_id", string(eventID)),
-	)
-
-	return nil
+	select {
+	case <-future.Ok():
+		logger.Debugw("Published event to JetStream",
+			zap.String("subject", subject),
+			zap.String("event_id", string(eventID)),
+		)
+		return nil
+	case ackErr := <-future.Err():
+		logger.Errorw("JetStream rejected the published event",
+			zap.Error(ackErr),
+			zap.String("subject", subject),
+			zap.String("event_id", string(eventID)),
+		)
+		return fmt.Errorf("%w: %v", errPublishUnavailable, ackErr)
+	case <-pubCtx.Done():
+		logger.Errorw("Timed out waiting for JetStream ack",
+			zap.Error(pubCtx.Err()),
+			zap.String("subject", subject),
+			zap.String("event_id", string(eventID)),
+		)
+		return fmt.Errorf("%w: %v", errPublishUnavailable, pubCtx.Err())
+	}
 }
 
 // ReadinessChecker returns an http.HandlerFunc for readiness checks

--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	natstest "github.com/nats-io/nats-server/v2/test"
@@ -264,6 +265,62 @@ func TestServeHTTP_InvalidCloudEvent(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Status code = %v, want %v", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestServeHTTP_PublishUnavailableReturns503(t *testing.T) {
+	s := runBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("Failed to get JetStream context: %v", err)
+	}
+
+	// Deliberately do NOT create a stream for this broker's subject, so no ack
+	// ever comes back. With a short publish timeout the handler should return
+	// 503 (ask the producer to retry) rather than 500.
+	handler := NewHandler(HandlerConfig{
+		Logger:         zap.NewNop().Sugar(),
+		JetStream:      js,
+		PublishTimeout: 300 * time.Millisecond,
+	})
+	handler.UpdateContract(&contract.Contract{
+		Brokers: map[string]contract.BrokerContract{
+			"test-namespace/no-stream": {
+				Namespace:      "test-namespace",
+				Name:           "no-stream",
+				Path:           "/test-namespace/no-stream",
+				PublishSubject: "test-namespace.no-stream._knative_broker",
+				StreamName:     "MISSING_STREAM",
+			},
+		},
+	})
+
+	event := map[string]interface{}{
+		"specversion": "1.0",
+		"type":        "test.type",
+		"source":      "test/source",
+		"id":          "test-id-503",
+	}
+	eventJSON, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/test-namespace/no-stream", bytes.NewBuffer(eventJSON))
+	req.Header.Set("Content-Type", "application/cloudevents+json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("Status code = %v, want %v", w.Code, http.StatusServiceUnavailable)
+	}
+	if got := w.Header().Get("Retry-After"); got == "" {
+		t.Error("expected Retry-After header to be set on 503")
 	}
 }
 


### PR DESCRIPTION
Why

Under high load the shared NATS broker ingress fails with nats: timeout and returns HTTP 500 to producers:

```
"msg":"Failed to publish event to JetStream","broker":"default","namespace":"default","error":"nats: timeout"
```

The ingress published with the synchronous js.Publish, which blocks each request on a full request → persist → ack round trip (default 5s wait), one message at a time per goroutine. That caps throughput at roughly concurrency / ack-latency, and when JetStream can't ack within the window the producer gets a hard 500 — which most CloudEvents senders don't retry.

Proposed Changes

Switch the ingress publish path to async-publish-with-wait, keeping the same durability guarantee while letting many publishes be in flight:

- Use js.PublishAsync and wait for the PubAck before responding. A 202 is still only returned after JetStream durably stores the event — no premature acks.
- Bound the wait with the request context (PUBLISH_TIMEOUT, default 10s) so a lost ack can't hang the request.
- Create the JetStream context with nats.PublishAsyncMaxPending (PUBLISH_MAX_INFLIGHT, default 256) so publishes pipeline and a full window applies backpressure.
- Map backpressure / ack-timeout / publish errors to 503 + Retry-After (producers back off and retry) instead of 500. Retries are safe because publishes carry nats.MsgId, so the stream's dedup window drops duplicates.
- Non-publish failures (e.g. event encoding) still return 500.

New configuration (ingress deployment)

```
┌──────────────────────┬─────────┬───────────────────────────────────────────────────────────────────────────────────┐
│       Env var        │ Default │                                      Purpose                                      │
├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────┤
│ PUBLISH_TIMEOUT      │ 10s     │ Max time a request waits for a JetStream ack before returning 503.                │
├──────────────────────┼─────────┼───────────────────────────────────────────────────────────────────────────────────┤
│ PUBLISH_MAX_INFLIGHT │ 256     │ Max outstanding (unacked) async publishes; caps memory and provides backpressure. │
└──────────────────────┴─────────┴───────────────────────────────────────────────────────────────────────────────────┘
```

Behavior / Compatibility

- Durability unchanged — an event is only 202'd once JetStream confirms it's stored (same signal js.Publish waited for internally).
- Under overload — fast 503 + Retry-After instead of a stuck ~5s sync call ending in 500.
- Throughput — many concurrent in-flight publishes instead of serialized round trips.
- PUBLISH_TIMEOUT (10s) stays below the HTTP WriteTimeout (30s) so the 503 is always writable; raising it above 30s would require bumping the HTTP write timeout too.