### PR TITLE
Change per instance annotation to expect configmap

### DIFF
--- a/docs/broker.md
+++ b/docs/broker.md
@@ -186,29 +186,47 @@ These variables set the **broker-wide defaults** for the filter deployment. All 
 | `CONSUMER_FETCH_TIMEOUT` | How long a fetch waits for messages before returning empty | `200ms` |
 | `CONSUMER_MAX_CONCURRENCY` | Maximum concurrent in-flight HTTP dispatches per trigger | `20` |
 
-### Configuring Consumer Fetch via Broker Annotation
+### Configuring a Broker via a Config ConfigMap
 
-Set broker-wide defaults for all triggers using the `natsjetstream.eventing.knative.dev/config` annotation. These are injected as environment variables into the filter deployment.
+Per-broker configuration lives in a **ConfigMap in the broker's namespace**, referenced **by name** through the `natsjetstream.eventing.knative.dev/config` annotation (the annotation value is the ConfigMap name, *not* inline config). The ConfigMap holds a `NatsJetStreamBrokerConfig` — as YAML or JSON — under the `config` key. It covers the JetStream `stream` settings and the `filter` deployment, whose `env` entries become environment variables on the filter (e.g. the consumer-fetch defaults above).
 
 ```yaml
+# 1) The config ConfigMap — must be in the same namespace as the Broker.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-broker-config
+  namespace: default
+data:
+  config: |
+    filter:
+      replicas: 2
+      env:
+        - name: CONSUMER_FETCH_BATCH_SIZE
+          value: "50"
+        - name: CONSUMER_FETCH_TIMEOUT
+          value: "1s"
+        - name: CONSUMER_MAX_CONCURRENCY
+          value: "40"
+    stream:
+      replicas: 3
+---
+# 2) The Broker references the ConfigMap by name.
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   name: my-broker
+  namespace: default
   annotations:
     eventing.knative.dev/broker.class: NatsJetStreamBroker
-    natsjetstream.eventing.knative.dev/config: |
-      {
-        "filter": {
-          "replicas": 2,
-          "env": [
-            {"name": "CONSUMER_FETCH_BATCH_SIZE", "value": "50"},
-            {"name": "CONSUMER_FETCH_TIMEOUT", "value": "1s"},
-            {"name": "CONSUMER_MAX_CONCURRENCY", "value": "40"}
-          ]
-        }
-      }
+    natsjetstream.eventing.knative.dev/config: my-broker-config
 ```
+
+Notes:
+
+- The annotation value is the ConfigMap **name**; the ConfigMap must exist in the **broker's namespace**. If it is missing or its `config` key can't be parsed, the broker reports a reconciliation error.
+- This per-broker ConfigMap takes precedence over the cluster/namespace default ConfigMap (`natsjetstream-broker-config`) and is used **as a whole** — the two are not merged.
+- Config is read at reconcile time. `stream` settings are applied when the stream is **created** (create-once), so changing them on an existing broker requires recreating the stream; `filter` changes roll out to the filter deployment on the next reconcile.
 
 ### Per-Trigger Configuration
 

--- a/pkg/broker/config/config.go
+++ b/pkg/broker/config/config.go
@@ -36,7 +36,9 @@ const (
 	ConfigKey = "config"
 )
 
-// BrokerConfigAnnotation is the annotation key for broker-specific configuration
+// BrokerConfigAnnotation is the annotation key whose value is the NAME of a
+// ConfigMap (in the broker's own namespace) that holds this broker's
+// NatsJetStreamBrokerConfig under the ConfigKey ("config") key.
 const BrokerConfigAnnotation = "natsjetstream.eventing.knative.dev/config"
 
 // DefaultBrokerConfig returns the default configuration for a broker
@@ -80,21 +82,28 @@ func LoadDefaultsFromConfigMap(cm *corev1.ConfigMap) (*NatsJetStreamBrokerDefaul
 	return defaults, nil
 }
 
-// GetConfigFromAnnotation extracts broker config from annotations.
-// Returns nil, nil if no annotation is present.
-func GetConfigFromAnnotation(annotations map[string]string) (*NatsJetStreamBrokerConfig, error) {
-	if annotations == nil {
-		return nil, nil
+// ParseBrokerConfig parses a per-broker NatsJetStreamBrokerConfig from a
+// ConfigMap. The config is expected under the ConfigKey ("config") key as YAML
+// or JSON. Unlike the cluster/namespace defaults ConfigMap, this is a bare
+// NatsJetStreamBrokerConfig (no clusterDefault/namespaceDefaults wrapper).
+func ParseBrokerConfig(cm *corev1.ConfigMap) (*NatsJetStreamBrokerConfig, error) {
+	if cm == nil {
+		return nil, fmt.Errorf("nil config map")
 	}
 
-	configJSON, ok := annotations[BrokerConfigAnnotation]
-	if !ok || configJSON == "" {
-		return nil, nil
+	data, ok := cm.Data[ConfigKey]
+	if !ok || data == "" {
+		return nil, fmt.Errorf("config map %q has no %q key", cm.Name, ConfigKey)
+	}
+
+	jsonData, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert config YAML to JSON: %w", err)
 	}
 
 	brokerConfig := &NatsJetStreamBrokerConfig{}
-	if err := json.Unmarshal([]byte(configJSON), brokerConfig); err != nil {
-		return nil, fmt.Errorf("failed to parse broker config annotation: %w", err)
+	if err := json.Unmarshal(jsonData, brokerConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal broker config: %w", err)
 	}
 	return brokerConfig, nil
 }

--- a/pkg/broker/config/config_test.go
+++ b/pkg/broker/config/config_test.go
@@ -189,53 +189,40 @@ namespaceDefaults:
 	}
 }
 
-func TestGetConfigFromAnnotation(t *testing.T) {
+func TestParseBrokerConfig(t *testing.T) {
 	tests := []struct {
-		name        string
-		annotations map[string]string
-		want        *NatsJetStreamBrokerConfig
-		wantErr     bool
+		name    string
+		data    map[string]string
+		want    *NatsJetStreamBrokerConfig
+		wantErr bool
 	}{
 		{
-			name:        "nil annotations",
-			annotations: nil,
-			want:        nil,
+			name:    "missing config key",
+			data:    map[string]string{"other": "value"},
+			wantErr: true,
 		},
 		{
-			name:        "empty annotations",
-			annotations: map[string]string{},
-			want:        nil,
+			name:    "empty config value",
+			data:    map[string]string{ConfigKey: ""},
+			wantErr: true,
 		},
 		{
-			name: "no broker config annotation",
-			annotations: map[string]string{
-				"some-other-annotation": "value",
-			},
-			want: nil,
-		},
-		{
-			name: "empty broker config annotation",
-			annotations: map[string]string{
-				BrokerConfigAnnotation: "",
-			},
-			want: nil,
-		},
-		{
-			name: "valid broker config annotation",
-			annotations: map[string]string{
-				BrokerConfigAnnotation: `{"stream":{"replicas":3}}`,
-			},
+			name: "valid JSON",
+			data: map[string]string{ConfigKey: `{"stream":{"replicas":3}}`},
 			want: &NatsJetStreamBrokerConfig{
-				Stream: &v1alpha1.StreamConfig{
-					Replicas: 3,
-				},
+				Stream: &v1alpha1.StreamConfig{Replicas: 3},
+			},
+		},
+		{
+			name: "valid YAML",
+			data: map[string]string{ConfigKey: "stream:\n  replicas: 5\n  storage: Memory\n"},
+			want: &NatsJetStreamBrokerConfig{
+				Stream: &v1alpha1.StreamConfig{Replicas: 5, Storage: v1alpha1.MemoryStorage},
 			},
 		},
 		{
 			name: "filter topology spread constraints",
-			annotations: map[string]string{
-				BrokerConfigAnnotation: `{"filter":{"topologySpreadConstraints":[{"maxSkew":1,"minDomains":2,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"DoNotSchedule","labelSelector":{"matchLabels":{"eventing.knative.dev/broker":"example-broker","eventing.knative.dev/role":"filter"}},"matchLabelKeys":["pod-template-hash"]}]}}`,
-			},
+			data: map[string]string{ConfigKey: `{"filter":{"topologySpreadConstraints":[{"maxSkew":1,"minDomains":2,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"DoNotSchedule","labelSelector":{"matchLabels":{"eventing.knative.dev/broker":"example-broker","eventing.knative.dev/role":"filter"}},"matchLabelKeys":["pod-template-hash"]}]}}`},
 			want: &NatsJetStreamBrokerConfig{
 				Filter: &DeploymentTemplate{
 					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
@@ -257,23 +244,28 @@ func TestGetConfigFromAnnotation(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid JSON in annotation",
-			annotations: map[string]string{
-				BrokerConfigAnnotation: `{invalid json}`,
-			},
+			name:    "type mismatch",
+			data:    map[string]string{ConfigKey: `{"stream":"not-an-object"}`},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetConfigFromAnnotation(tt.annotations)
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "broker-cfg", Namespace: "ns"},
+				Data:       tt.data,
+			}
+			got, err := ParseBrokerConfig(cm)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetConfigFromAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ParseBrokerConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
 				return
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("GetConfigFromAnnotation() mismatch (-want +got):\n%s", diff)
+				t.Errorf("ParseBrokerConfig() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -458,8 +450,8 @@ func TestBuildNatsStreamConfig(t *testing.T) {
 	}
 }
 
-func TestBrokerConfigAnnotationRoundTrip(t *testing.T) {
-	// Test that we can serialize and deserialize broker config through annotation
+func TestBrokerConfigConfigMapRoundTrip(t *testing.T) {
+	// Test that we can serialize a config into a ConfigMap and parse it back.
 	original := &NatsJetStreamBrokerConfig{
 		Stream: &v1alpha1.StreamConfig{
 			Replicas: 3,
@@ -470,21 +462,19 @@ func TestBrokerConfigAnnotationRoundTrip(t *testing.T) {
 		},
 	}
 
-	// Serialize to JSON
 	data, err := json.Marshal(original)
 	if err != nil {
 		t.Fatalf("Failed to marshal config: %v", err)
 	}
 
-	// Create annotation map
-	annotations := map[string]string{
-		BrokerConfigAnnotation: string(data),
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker-cfg", Namespace: "ns"},
+		Data:       map[string]string{ConfigKey: string(data)},
 	}
 
-	// Deserialize through GetConfigFromAnnotation
-	got, err := GetConfigFromAnnotation(annotations)
+	got, err := ParseBrokerConfig(cm)
 	if err != nil {
-		t.Fatalf("GetConfigFromAnnotation() error = %v", err)
+		t.Fatalf("ParseBrokerConfig() error = %v", err)
 	}
 
 	if diff := cmp.Diff(original, got); diff != "" {

--- a/pkg/broker/controller/reconciler.go
+++ b/pkg/broker/controller/reconciler.go
@@ -279,15 +279,22 @@ func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, b *eventingv1.Br
 func (r *Reconciler) getBrokerConfig(ctx context.Context, b *eventingv1.Broker) (*brokerconfig.NatsJetStreamBrokerConfig, error) {
 	logger := logging.FromContext(ctx)
 
-	// Check for broker-specific annotation first (highest priority)
-	if cfg, err := brokerconfig.GetConfigFromAnnotation(b.Annotations); err != nil {
-		return nil, err
-	} else if cfg != nil {
-		logger.Debugw("Using broker-specific config from annotation")
+	// Broker-specific config (highest priority): the annotation names a ConfigMap
+	// in the broker's namespace holding this broker's config.
+	if cmName := b.Annotations[brokerconfig.BrokerConfigAnnotation]; cmName != "" {
+		cm, err := r.kubeClientSet.CoreV1().ConfigMaps(b.Namespace).Get(ctx, cmName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get broker config ConfigMap %q in namespace %q: %w", cmName, b.Namespace, err)
+		}
+		cfg, err := brokerconfig.ParseBrokerConfig(cm)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse broker config from ConfigMap %q: %w", cmName, err)
+		}
+		logger.Debugw("Using broker-specific config from ConfigMap", zap.String("configmap", cmName))
 		return cfg, nil
 	}
 
-	// No annotation config, try to load from ConfigMap
+	// No annotation config, try to load namespace/cluster defaults from ConfigMap
 	cm, err := r.kubeClientSet.CoreV1().ConfigMaps(b.Namespace).Get(ctx, brokerconfig.ConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrs.IsNotFound(err) {

--- a/pkg/broker/controller/reconciler_test.go
+++ b/pkg/broker/controller/reconciler_test.go
@@ -213,16 +213,29 @@ func TestReconcileDataplaneRBAC(t *testing.T) {
 func TestGetBrokerConfig(t *testing.T) {
 	ctx := testContext()
 
-	t.Run("from broker annotation", func(t *testing.T) {
-		r := &Reconciler{kubeClientSet: kubefake.NewSimpleClientset()}
+	t.Run("from ConfigMap named by broker annotation", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-broker-cfg", Namespace: testNamespace},
+			Data:       map[string]string{brokerconfig.ConfigKey: `{"stream":{"replicas":3}}`},
+		}
+		r := &Reconciler{kubeClientSet: kubefake.NewSimpleClientset(cm)}
 		b := testBroker(testNamespace, testBrokerName)
-		b.Annotations = map[string]string{brokerconfig.BrokerConfigAnnotation: `{"stream":{"replicas":3}}`}
+		b.Annotations = map[string]string{brokerconfig.BrokerConfigAnnotation: "my-broker-cfg"}
 		cfg, err := r.getBrokerConfig(ctx, b)
 		if err != nil {
 			t.Fatalf("getBrokerConfig() error: %v", err)
 		}
 		if cfg.Stream == nil || cfg.Stream.Replicas != 3 {
 			t.Errorf("Stream.Replicas = %+v, want 3", cfg.Stream)
+		}
+	})
+
+	t.Run("annotation names a missing ConfigMap is an error", func(t *testing.T) {
+		r := &Reconciler{kubeClientSet: kubefake.NewSimpleClientset()}
+		b := testBroker(testNamespace, testBrokerName)
+		b.Annotations = map[string]string{brokerconfig.BrokerConfigAnnotation: "does-not-exist"}
+		if _, err := r.getBrokerConfig(ctx, b); err == nil {
+			t.Error("getBrokerConfig() expected an error for a missing ConfigMap, got nil")
 		}
 	})
 


### PR DESCRIPTION
Why

Per-broker configuration was passed as inline JSON in the natsjetstream.eventing.knative.dev/config annotation. That's awkward to author and review, unbounded in size, and diverges from how the cluster/namespace defaults are supplied (a ConfigMap). This changes the annotation to hold the name of a ConfigMap in the broker's namespace, so per-broker config is authored like any other config resource (YAML or JSON) and can be managed/GitOps'd independently of the Broker object.

Proposed Changes

- The natsjetstream.eventing.knative.dev/config annotation value is now a ConfigMap name (in the broker's namespace), not inline config.
- The referenced ConfigMap holds a bare NatsJetStreamBrokerConfig under the config key, parsed as YAML or JSON (via yaml.YAMLToJSON) — not the clusterDefault/namespaceDefaults wrapper used by the cluster-wide defaults ConfigMap.
- pkg/broker/config: removed the inline-JSON parser GetConfigFromAnnotation; added ParseBrokerConfig(cm) which errors clearly on a nil ConfigMap, a missing/empty config key, or a parse/type mismatch.
- pkg/broker/controller (getBrokerConfig): when the annotation is set, Get the named ConfigMap from the broker's namespace and parse it; a missing ConfigMap or parse failure is now surfaced as a reconciliation error (visible in Broker status) instead of being silently ignored.
- The annotation is optional and precedence is unchanged: annotation-named ConfigMap → cluster/namespace default ConfigMap (natsjetstream-broker-config) → hardcoded defaults. Config is used as a whole (not merged).
- Updated docs/broker.md to the ConfigMap approach and to state the annotation is optional.

Behavior / Compatibility

- Breaking: brokers that currently put inline JSON in this annotation will fail reconciliation (the value is now treated as a ConfigMap name → "not found"). Migrate by moving the JSON/YAML into a ConfigMap and setting the annotation to its name.